### PR TITLE
🐛 fix(next): add Image loader prop for static export

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "[typescript]": {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,6 +35,7 @@ export default function Header() {
             priority
             loading="eager"
             quality={100}
+            loader={({ src }) => src}
           />
         </Link>
         <nav className={`${styles.nav} ${margarine.className}`}>


### PR DESCRIPTION
* Add custom loader prop to Header Image component for Next.js static export
* Update VSCode settings for ESLint auto-fix to use explicit mode

This change resolves the Next.js build error for static exports by properly configuring the Image component with a required loader prop.