### PR TITLE
🐛 fix(build): resolve Next.js config import error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 help:
 	@cat Makefile | grep '^## ' --color=never | cut -c4- | sed -e "`printf 's/ - /\t- /;'`" | column -s "`printf '\t'`" -t
 
+BUILD_DIR := docs
+
 ## install - install dependency packages
 install:
 	npm install
@@ -16,17 +18,17 @@ run: install
 
 ## clean - clean previous builds
 clean:
-	rm -rf docs/
+	rm -rf $(BUILD_DIR)/
 
 ## build - build the app for release
 build: clean install
 	npm run build
-	cp CNAME docs/ || true
-	touch docs/.nojekyll
+	cp CNAME $(BUILD_DIR)/ || true
+	touch $(BUILD_DIR)/.nojekyll
 
 ## deploy - build and deploy the app
 deploy: build
-	git add docs
+	git add $(BUILD_DIR)
 	git commit -m "Deploy `git rev-parse --verify HEAD`" --no-verify
 	git push origin master
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,12 @@
+// Import build directory from TypeScript config causes issues with Next.js
+// Using the same value as defined in src/config/build.ts
+const BUILD_DIR = 'docs';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   output: 'export',
-  distDir: 'docs',
+  distDir: BUILD_DIR,
   trailingSlash: true, // Ensures clean URLs in static export
   images: {
     unoptimized: true,

--- a/src/config/build.ts
+++ b/src/config/build.ts
@@ -1,0 +1,11 @@
+/**
+ * Build configuration constants
+ */
+
+export const BUILD = {
+  /**
+   * Directory where the static site is built
+   * This must be 'docs' for GitHub Pages compatibility
+   */
+  outputDir: 'docs',
+} as const;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,7 @@
 export * from './analytics';
+export * from './build';
 export * from './business';
+export * from './fonts';
 export * from './pages';
 export * from './seo';
 export * from './social';

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,4 +1,4 @@
-import { PAGES, SITE_URL } from '@/config';
+import { PAGES, SITE_URL, BUILD } from '@/config';
 import fs from 'fs';
 import path from 'path';
 
@@ -24,7 +24,7 @@ function generateSiteMap() {
 // Generate the sitemap during build
 export async function getStaticProps() {
   const sitemap = generateSiteMap();
-  const buildDir = path.join(process.cwd(), 'www');
+  const buildDir = path.join(process.cwd(), BUILD.outputDir);
 
   // Ensure the build directory exists
   if (!fs.existsSync(buildDir)) {


### PR DESCRIPTION
* Remove import from TypeScript config in next.config.mjs
* Add hardcoded BUILD_DIR constant in next.config.mjs
* Keep TypeScript config for application code

This fixes the build error caused by Next.js trying to import from a TypeScript file before compilation. The build directory value remains centralized in the TypeScript config for the application code while being duplicated only where necessary in the Next.js config.