### PR TITLE
✨ feat(menu): Add TV display mode and refactor menu components

### DIFF
--- a/.cursor/rules/menu.mdc
+++ b/.cursor/rules/menu.mdc
@@ -141,3 +141,24 @@ Learning:
 - Clear fallback for missing images
 
 Tags: #images #performance #ux
+
+### TV Display Feature
+Category: User Experience
+Date: 2024-03-27
+Context:
+- Need to showcase featured menu items in a TV display format
+- Images need to transition smoothly
+- Display needs to be configurable in real-time
+- Screen needs to stay awake
+
+Learning:
+- Implement configurable transition delays (3-30 seconds)
+- Use keyboard shortcuts for real-time control:
+  - Left/Right arrows for manual navigation
+  - +/- keys for adjusting transition speed
+- Use Wake Lock API to prevent screen sleep
+- Maintain consistent transition animations with CSS
+- Use clear naming conventions for timing constants (e.g., `*_MILLIS` suffix)
+- Separate client-side menu utilities from server-side data loading
+
+Tags: #tv-display #ux #animations #keyboard-shortcuts

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -1,0 +1,82 @@
+import Image from 'next/image';
+
+import { MenuItemState, MenuItem as MenuItemType } from '@/types/menu';
+
+import styles from '@/styles/Menu.module.css';
+
+interface MenuItemProps {
+  item: MenuItemType;
+  index: number;
+  totalItems: number;
+  itemState: MenuItemState;
+  onImageLoad: (itemId: string) => void;
+  onKeyDown: (e: React.KeyboardEvent, index: number, totalItems: number) => void;
+  setRef?: (el: HTMLDivElement | null) => void;
+}
+
+export default function MenuItem({
+  item,
+  index,
+  totalItems,
+  itemState,
+  onImageLoad,
+  onKeyDown,
+  setRef,
+}: MenuItemProps) {
+  return (
+    <div
+      key={item.guid}
+      className={`${styles.menuItem} ${itemState.isLoaded ? styles.loaded : ''}`}
+      role="article"
+      aria-labelledby={`item-name-${item.guid}`}
+      tabIndex={0}
+      ref={setRef}
+      data-item-id={item.guid}
+      onKeyDown={(e) => onKeyDown(e, index, totalItems)}
+    >
+      {item.isPopular && (
+        <div className={styles.itemBadge} aria-label="Popular item">
+          Popular
+        </div>
+      )}
+      <div className={styles.imageContainer}>
+        {item.imageUrl ? (
+          <>
+            {!itemState.isLoaded && <div className={styles.imagePlaceholder} aria-hidden="true" />}
+            <Image
+              src={item.imageUrl}
+              alt={`Photo of ${item.name}`}
+              width={1980}
+              height={1080}
+              className={`${styles.image} ${itemState.isLoaded ? styles.loaded : ''}`}
+              onLoad={() => onImageLoad(item.guid)}
+              priority={index < 4}
+              loader={({ src }) => src}
+            />
+          </>
+        ) : (
+          <div className={styles.imagePlaceholder} aria-label="No image available">
+            <div className={styles.noImageIcon}>
+              <span>No image available</span>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className={styles.itemDetails}>
+        <div className={styles.itemHeader}>
+          <h3 id={`item-name-${item.guid}`} className={styles.itemName}>
+            {item.name}
+          </h3>
+          <span className={styles.price} aria-label={`Price: $${item.price.toFixed(2)}`}>
+            ${item.price.toFixed(2)}
+          </span>
+        </div>
+        {item.description && (
+          <p className={styles.description} aria-label={`Description: ${item.description}`}>
+            {item.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tv.tsx
+++ b/src/pages/tv.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { GetStaticProps } from 'next';
+import Image from 'next/image';
+
+import { MenuItem } from '@/types/menu';
+
+import { margarine } from '@/config/fonts';
+
+import { getFeaturedItems, imageLoader } from '@/utils/menu';
+import { loadMenuData } from '@/utils/menu_static';
+
+import styles from '@/styles/TV.module.css';
+
+interface TVPageProps {
+  featuredItems: MenuItem[];
+}
+
+const MIN_DELAY_MILLIS = 3000; // 3 seconds minimum
+const MAX_DELAY_MILLIS = 30000; // 30 seconds maximum
+const DELAY_STEP_MILLIS = 1000; // 1 second increments
+const DEFAULT_DELAY_MILLIS = 5000; // 5 seconds default
+
+export default function TV({ featuredItems }: TVPageProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [transitionDelay, setTransitionDelay] = useState(DEFAULT_DELAY_MILLIS);
+
+  const goToNext = useCallback(() => {
+    setIsTransitioning(true);
+    setTimeout(() => {
+      setCurrentIndex((current) => (current + 1) % featuredItems.length);
+      setIsTransitioning(false);
+    }, 1000); // Match this with CSS transition duration
+  }, [featuredItems.length]);
+
+  const goToPrevious = useCallback(() => {
+    setIsTransitioning(true);
+    setTimeout(() => {
+      setCurrentIndex((current) => (current - 1 + featuredItems.length) % featuredItems.length);
+      setIsTransitioning(false);
+    }, 1000);
+  }, [featuredItems.length]);
+
+  const adjustDelay = useCallback((amount: number) => {
+    setTransitionDelay((current) => {
+      const newDelay = current + amount;
+      return Math.min(Math.max(newDelay, MIN_DELAY_MILLIS), MAX_DELAY_MILLIS);
+    });
+  }, []);
+
+  // Handle keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowRight':
+          goToNext();
+          break;
+        case 'ArrowLeft':
+          goToPrevious();
+          break;
+        case '+':
+        case '=': // Also support = key since it's the same key as + without shift
+          adjustDelay(DELAY_STEP_MILLIS);
+          break;
+        case '-':
+        case '_': // Also support _ key since it's the same key as - without shift
+          adjustDelay(-DELAY_STEP_MILLIS);
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [goToNext, goToPrevious, adjustDelay]);
+
+  // Auto-advance slides
+  useEffect(() => {
+    const timer = setInterval(goToNext, transitionDelay);
+    return () => clearInterval(timer);
+  }, [transitionDelay, goToNext]);
+
+  // Prevent screen saver and display sleep
+  useEffect(() => {
+    const preventSleep = async () => {
+      try {
+        // @ts-ignore - TypeScript doesn't know about wake lock API yet
+        const wakeLock = await navigator.wakeLock.request('screen');
+        return () => wakeLock.release();
+      } catch (err) {
+        console.log('Wake Lock not supported or failed:', err);
+      }
+    };
+
+    preventSleep();
+  }, []);
+
+  const currentItem = featuredItems[currentIndex];
+
+  if (!currentItem) return null;
+
+  return (
+    <div className={styles.tvContainer}>
+      <div
+        className={`${styles.slide} ${isTransitioning ? styles.transitioning : ''}`}
+        key={currentItem.guid}
+      >
+        {currentItem.imageUrl && (
+          <div className={styles.imageContainer}>
+            <Image
+              src={currentItem.imageUrl}
+              alt={currentItem.name}
+              fill
+              style={{ objectFit: 'cover' }}
+              quality={100}
+              priority
+              loader={imageLoader}
+              unoptimized
+            />
+            <div className={styles.overlay} />
+          </div>
+        )}
+        <div className={styles.content}>
+          <h1 className={`${styles.title} ${margarine.className}`}>{currentItem.name}</h1>
+          {currentItem.description && (
+            <p className={styles.description}>{currentItem.description}</p>
+          )}
+          <p className={styles.price}>${currentItem.price.toFixed(2)}</p>
+          <p className={styles.delay}>Transition delay: {transitionDelay / 1000}s</p>
+        </div>
+      </div>
+      <div className={styles.logo}>
+        <Image
+          src="/images/logos/skilletz_logo_dark_mode_blue_flame_transparent.png"
+          alt="Skilletz Logo"
+          width={240}
+          height={70}
+          style={{ objectFit: 'contain' }}
+          loader={imageLoader}
+          unoptimized
+        />
+      </div>
+    </div>
+  );
+}
+
+export const getStaticProps: GetStaticProps<TVPageProps> = async () => {
+  const menuData = loadMenuData();
+  const featuredItems = getFeaturedItems(menuData);
+
+  return {
+    props: {
+      featuredItems,
+    },
+  };
+};

--- a/src/styles/TV.module.css
+++ b/src/styles/TV.module.css
@@ -1,0 +1,103 @@
+.tvContainer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: black;
+  overflow: hidden;
+}
+
+.slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 1;
+  transition: opacity 1s ease-in-out;
+}
+
+.slide.transitioning {
+  opacity: 0;
+}
+
+.imageContainer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border: 12px solid #000;
+  box-sizing: border-box;
+}
+
+.overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40%;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.9), transparent);
+  z-index: 1;
+}
+
+.content {
+  position: absolute;
+  bottom: 40px;
+  left: 40px;
+  right: 40px;
+  color: white;
+  z-index: 2;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.title {
+  font-size: 4rem;
+  margin: 0 0 0.5rem;
+  color: white;
+}
+
+.description {
+  font-size: 2rem;
+  margin: 0 0 1rem;
+  opacity: 0.9;
+  max-width: 80%;
+}
+
+.price {
+  font-size: 3rem;
+  margin: 0;
+  color: #fff;
+  font-weight: bold;
+}
+
+.logo {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  width: 240px;
+  height: 70px;
+  z-index: 3;
+  opacity: 0.8;
+  transition: opacity 0.3s ease;
+}
+
+.logo:hover {
+  opacity: 1;
+}
+
+.delay {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.6);
+  background: rgba(0, 0, 0, 0.5);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.tvContainer:hover .delay {
+  opacity: 1;
+}

--- a/src/types/menu.ts
+++ b/src/types/menu.ts
@@ -1,0 +1,31 @@
+export interface MenuItem {
+  name: string;
+  guid: string;
+  description: string;
+  price: number;
+  imageUrl: string | null;
+  isPopular?: boolean;
+}
+
+export interface MenuGroup {
+  name: string;
+  guid: string;
+  description: string;
+  items: MenuItem[];
+}
+
+export interface Menu {
+  name: string;
+  guid: string;
+  description: string;
+  groups: MenuGroup[];
+}
+
+export interface MenuData {
+  menus: Menu[];
+}
+
+export interface MenuItemState {
+  isVisible: boolean;
+  isLoaded: boolean;
+}

--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -1,0 +1,20 @@
+import { MenuData } from '@/types/menu';
+
+// Image loader for external images
+export const imageLoader = ({ src }: { src: string }) => {
+  return src;
+};
+
+// Filter out "Other" menu and get featured items
+export const getFeaturedItems = (menuData: MenuData) => {
+  return menuData.menus.flatMap((menu) =>
+    menu.groups.flatMap((group) =>
+      group.items.filter((item) => item.imageUrl && (item.isPopular || Math.random() < 0.3))
+    )
+  );
+};
+
+// Filter out "Other" menu
+export const getMainMenus = (menuData: MenuData) => {
+  return menuData.menus.filter((menu) => menu.name !== 'Other');
+};

--- a/src/utils/menu_static.ts
+++ b/src/utils/menu_static.ts
@@ -1,0 +1,9 @@
+import { MenuData } from '@/types/menu';
+import fs from 'fs';
+import path from 'path';
+
+// Server-side only: Load menu data from JSON file
+export const loadMenuData = (): MenuData => {
+  const menuDataPath = path.join(process.cwd(), 'src/data/menu/processed/menu.json');
+  return JSON.parse(fs.readFileSync(menuDataPath, 'utf-8'));
+};


### PR DESCRIPTION
Add new TV display mode for showcasing featured menu items with:
- Configurable transition delays (3-30s) using keyboard shortcuts
- Smooth image transitions and overlay effects
- Wake Lock API integration to prevent screen sleep
- Real-time control with arrow keys for navigation

Refactor menu system:
- Extract MenuItem into reusable component
- Move interfaces to dedicated `types/menu.ts`
- Split menu utilities into client/server (`menu.ts/menu_static.ts`)
- Document TV display learnings in menu.mdc

BREAKING CHANGE: Menu interfaces moved to `@/types/menu`