### PR TITLE
fix: track order clickthroughs in static export

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,7 +1,3 @@
-import { GoogleAnalytics } from '@hacktoolkit/nextjs-htk/components';
-
-import { ANALYTICS } from '@/config/analytics';
-
 import StructuredData from '@/components/StructuredData';
 
 import '@/styles/globals.css';
@@ -9,7 +5,6 @@ import '@/styles/globals.css';
 export default function App({ Component, pageProps }) {
   return (
     <>
-      <GoogleAnalytics measurementId={ANALYTICS.google.measurementId} />
       <StructuredData />
       <Component {...pageProps} />
     </>

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,10 +1,23 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
+import { ANALYTICS } from '@/config/analytics';
+
+const googleAnalyticsSrc = `https://www.googletagmanager.com/gtag/js?id=${ANALYTICS.google.measurementId}`;
+const googleAnalyticsConfig = `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  window.gtag = gtag;
+  gtag('js', new Date());
+  gtag('config', '${ANALYTICS.google.measurementId}');
+`;
+
 export default function Document() {
   return (
     <Html lang="en">
       <Head>
         <link rel="icon" href="/favicon.ico" />
+        <script async src={googleAnalyticsSrc}></script>
+        <script dangerouslySetInnerHTML={{ __html: googleAnalyticsConfig }} />
       </Head>
       <body>
         <Main />

--- a/src/pages/order-online-tearekz.tsx
+++ b/src/pages/order-online-tearekz.tsx
@@ -4,6 +4,8 @@ import { ORDERING_PARTNERS } from '@/config/orderingPartners';
 
 import { BasicPageLayout } from '@/components/BasicPageLayout';
 
+import { trackOutboundClick } from '@/utils/analytics';
+
 import styles from '@/styles/BasicPage.module.css';
 
 export default function OrderOnlineTeaRekz() {
@@ -11,7 +13,10 @@ export default function OrderOnlineTeaRekz() {
   const orderUrl = toastPartner?.url || 'https://order.toasttab.com/online/skilletz-cafe';
 
   useEffect(() => {
-    // Redirect after component mounts
+    trackOutboundClick({
+      destination: orderUrl,
+      label: 'order_online:tearekz_redirect',
+    });
     window.location.href = orderUrl;
   }, [orderUrl]);
 
@@ -22,7 +27,18 @@ export default function OrderOnlineTeaRekz() {
       intro="Redirecting you to our online ordering system..."
     >
       <div className={styles.card}>
-        <a href={orderUrl} target="_blank" rel="noopener noreferrer" className={styles.link}>
+        <a
+          href={orderUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.link}
+          onClick={() =>
+            trackOutboundClick({
+              destination: orderUrl,
+              label: 'order_online:tearekz_link',
+            })
+          }
+        >
           Order Tea-Rek&apos;z Online
         </a>
       </div>

--- a/src/pages/order-online-tearekz.tsx
+++ b/src/pages/order-online-tearekz.tsx
@@ -13,11 +13,45 @@ export default function OrderOnlineTeaRekz() {
   const orderUrl = toastPartner?.url || 'https://order.toasttab.com/online/skilletz-cafe';
 
   useEffect(() => {
-    trackOutboundClick({
+    let fallbackId: number | undefined;
+    let hasRedirected = false;
+
+    const redirectToOrdering = () => {
+      if (fallbackId !== undefined) {
+        window.clearTimeout(fallbackId);
+      }
+
+      if (hasRedirected) {
+        return;
+      }
+
+      hasRedirected = true;
+      window.location.href = orderUrl;
+    };
+
+    const isTracked = trackOutboundClick({
       destination: orderUrl,
+      eventTimeout: 1000,
       label: 'order_online:tearekz_redirect',
+      onComplete: redirectToOrdering,
     });
-    window.location.href = orderUrl;
+
+    if (!isTracked) {
+      redirectToOrdering();
+      return undefined;
+    }
+
+    if (hasRedirected) {
+      return undefined;
+    }
+
+    fallbackId = window.setTimeout(redirectToOrdering, 1200);
+
+    return () => {
+      if (fallbackId !== undefined) {
+        window.clearTimeout(fallbackId);
+      }
+    };
   }, [orderUrl]);
 
   return (

--- a/src/pages/order-online.tsx
+++ b/src/pages/order-online.tsx
@@ -2,6 +2,8 @@ import { ORDERING_PARTNERS } from '@/config';
 
 import { BasicPageLayout } from '@/components/BasicPageLayout';
 
+import { trackOutboundClick } from '@/utils/analytics';
+
 import styles from '@/styles/BasicPage.module.css';
 
 export default function OrderOnline() {
@@ -22,6 +24,12 @@ export default function OrderOnline() {
             target="_blank"
             rel="noopener noreferrer"
             className={styles.link}
+            onClick={() =>
+              trackOutboundClick({
+                destination: partner.url,
+                label: `order_online:${partner.key}`,
+              })
+            }
             style={{
               fontSize: '1.25rem',
               padding: '1rem 2rem',

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,16 +1,27 @@
+interface OutboundClickGtagParams {
+  event_category: 'outbound';
+  event_label: string;
+  link_url: string;
+  link_domain: string | null;
+  page_location: string;
+  transport_type: 'beacon';
+}
+
+type Gtag = (command: 'event', eventName: 'click', params: OutboundClickGtagParams) => void;
+
 declare global {
   interface Window {
-    gtag?: (...args: any[]) => void;
+    gtag?: Gtag;
   }
 }
 
 interface TrackOutboundClickParams {
   destination: string;
   label: string;
-  location: string;
+  pageLocation?: string;
 }
 
-export function trackOutboundClick({ destination, label, location }: TrackOutboundClickParams) {
+export function trackOutboundClick({ destination, label, pageLocation }: TrackOutboundClickParams) {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
     return;
   }
@@ -26,7 +37,7 @@ export function trackOutboundClick({ destination, label, location }: TrackOutbou
         return null;
       }
     })(),
-    page_location: location,
+    page_location: pageLocation ?? window.location.href,
     transport_type: 'beacon',
   });
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,32 @@
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+  }
+}
+
+interface TrackOutboundClickParams {
+  destination: string;
+  label: string;
+  location: string;
+}
+
+export function trackOutboundClick({ destination, label, location }: TrackOutboundClickParams) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return;
+  }
+
+  window.gtag('event', 'click', {
+    event_category: 'outbound',
+    event_label: label,
+    link_url: destination,
+    link_domain: (() => {
+      try {
+        return new URL(destination).hostname;
+      } catch {
+        return null;
+      }
+    })(),
+    page_location: location,
+    transport_type: 'beacon',
+  });
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -5,6 +5,8 @@ interface OutboundClickGtagParams {
   link_domain: string | null;
   page_location: string;
   transport_type: 'beacon';
+  event_callback?: () => void;
+  event_timeout?: number;
 }
 
 type Gtag = (command: 'event', eventName: 'click', params: OutboundClickGtagParams) => void;
@@ -17,13 +19,21 @@ declare global {
 
 interface TrackOutboundClickParams {
   destination: string;
+  eventTimeout?: number;
   label: string;
+  onComplete?: () => void;
   pageLocation?: string;
 }
 
-export function trackOutboundClick({ destination, label, pageLocation }: TrackOutboundClickParams) {
+export function trackOutboundClick({
+  destination,
+  eventTimeout,
+  label,
+  onComplete,
+  pageLocation,
+}: TrackOutboundClickParams): boolean {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
-    return;
+    return false;
   }
 
   window.gtag('event', 'click', {
@@ -39,5 +49,13 @@ export function trackOutboundClick({ destination, label, pageLocation }: TrackOu
     })(),
     page_location: pageLocation ?? window.location.href,
     transport_type: 'beacon',
+    ...(onComplete
+      ? {
+          event_callback: onComplete,
+          event_timeout: eventTimeout ?? 1000,
+        }
+      : {}),
   });
+
+  return true;
 }


### PR DESCRIPTION
## Summary
- Move Google Analytics setup into `_document` so the static GitHub Pages export emits the GA loader/config in HTML.
- Add a shared `trackOutboundClick` helper for outbound order-click events with destination metadata and beacon transport.
- Track Skillet'z and Tea-Rek'z online-order CTA clicks.
- Delay the Tea-Rek'z auto-redirect until GA confirms the event callback, with `event_timeout` plus a 1.2s fallback so users do not get stuck.

## Validation
- `npm run lint` — passes; existing `@next/next/no-img-element` warnings remain in unrelated blog/menu print files.
- `make build` — passes; existing warnings remain for image usage, large `/tv` and `/menu` page data, and npm audit summary.
- GitHub Actions `build` — passed on the latest push.

## Review notes
- Addressed Copilot feedback on the Tea-Rek'z redirect racing the async analytics event.
