### PR TITLE
fix: satisfy Proof HTML validation

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,7 +22,7 @@ export default function Footer() {
     <footer className={styles.footer}>
       <div className={styles.footerContent}>
         <div className={styles.footerSection}>
-          <h3 className={margarine.className}>Location & Hours</h3>
+          <h2 className={margarine.className}>Location & Hours</h2>
           <p>
             <a
               href={createGoogleMapsUrl(BUSINESS.name, FULL_ADDRESS)}
@@ -44,7 +44,7 @@ export default function Footer() {
         </div>
 
         <div className={styles.footerSection}>
-          <h3 className={margarine.className}>Connect With Us</h3>
+          <h2 className={margarine.className}>Connect With Us</h2>
           <div className={styles.socialLinks}>
             {socialMediaEntries.map(([key, { url, label, icon, title }]) => (
               <a
@@ -62,7 +62,7 @@ export default function Footer() {
         </div>
 
         <div className={styles.footerSection}>
-          <h3 className={margarine.className}>Quick Links</h3>
+          <h2 className={margarine.className}>Quick Links</h2>
           {QUICK_LINKS.map((link) => {
             const LinkComponent = link.isInternal ? Link : 'a';
             return (

--- a/src/components/blog/TagFilter.tsx
+++ b/src/components/blog/TagFilter.tsx
@@ -5,7 +5,7 @@ import styles from '@/styles/Blog.module.css';
 export function TagFilter({ tags, activeTagId }: { tags: any[]; activeTagId?: string }) {
   return (
     <div className={styles.tagsContainer}>
-      <h3>Filter by topic:</h3>
+      <h2>Filter by topic:</h2>
       <div className={styles.tags}>
         <Link
           href="/blog"

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -37,11 +37,7 @@ export function MenuItem({
       data-item-id={item.guid}
       onKeyDown={(e) => onKeyDown(e, index, totalItems)}
     >
-      {item.isPopular && (
-        <div className={styles.itemBadge} aria-label="Popular item">
-          Popular
-        </div>
-      )}
+      {item.isPopular && <div className={styles.itemBadge}>Popular</div>}
       <div className={styles.imageContainer}>
         {item.imageUrl ? (
           <>
@@ -58,7 +54,7 @@ export function MenuItem({
             />
           </>
         ) : (
-          <div className={styles.imagePlaceholder} aria-label="No image available">
+          <div className={styles.imagePlaceholder}>
             <div className={styles.noImageIcon}>
               <span>No image available</span>
             </div>
@@ -70,15 +66,9 @@ export function MenuItem({
           <h3 id={`item-name-${uniqueId}`} className={styles.itemName}>
             {item.name}
           </h3>
-          <span className={styles.price} aria-label={`Price: $${item.price.toFixed(2)}`}>
-            ${item.price.toFixed(2)}
-          </span>
+          <span className={styles.price}>${item.price.toFixed(2)}</span>
         </div>
-        {item.description && (
-          <p className={styles.description} aria-label={`Description: ${item.description}`}>
-            {item.description}
-          </p>
-        )}
+        {item.description && <p className={styles.description}>{item.description}</p>}
       </div>
     </div>
   );

--- a/src/components/menu/MenuSections.tsx
+++ b/src/components/menu/MenuSections.tsx
@@ -59,14 +59,7 @@ export const MenuSections: React.FC<MenuSectionsProps> = ({
           {section.name}
           <span className={styles.categoryDecoration}>✦</span>
         </h2>
-        {section.description && (
-          <p
-            className={styles.categoryDescription}
-            aria-label={`${section.name} category description`}
-          >
-            {section.description}
-          </p>
-        )}
+        {section.description && <p className={styles.categoryDescription}>{section.description}</p>}
         <div className={styles.menuGrid} role="list" aria-label={`${section.name} menu items`}>
           {getItems(section).map((item, itemIndex) => {
             const itemState = itemStates[item.guid] || {

--- a/src/components/menu/MenuSections.tsx
+++ b/src/components/menu/MenuSections.tsx
@@ -60,7 +60,7 @@ export const MenuSections: React.FC<MenuSectionsProps> = ({
           <span className={styles.categoryDecoration}>✦</span>
         </h2>
         {section.description && <p className={styles.categoryDescription}>{section.description}</p>}
-        <div className={styles.menuGrid} role="list" aria-label={`${section.name} menu items`}>
+        <div className={styles.menuGrid}>
           {getItems(section).map((item, itemIndex) => {
             const itemState = itemStates[item.guid] || {
               isVisible: false,

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,11 @@
+import { BasicPageLayout } from '@/components/BasicPageLayout';
+
+export default function Custom404() {
+  return (
+    <BasicPageLayout
+      title="Page Not Found"
+      heading="Page Not Found"
+      intro="Sorry, we couldn't find the page you're looking for."
+    />
+  );
+}

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -71,7 +71,7 @@ export default function BlogPost({ post }: BlogPostProps) {
           {/* Tags */}
           {post.tags && post.tags.length > 0 && (
             <div className={styles.postTags}>
-              <h3>Tags:</h3>
+              <h2>Tags:</h2>
               <div className={styles.tags}>
                 {post.tags.map((tag: any) => (
                   <Link key={tag.id} href={`/blog/tag/${tag.id}`} className={styles.tag}>

--- a/src/pages/press.tsx
+++ b/src/pages/press.tsx
@@ -41,7 +41,7 @@ export default function Press() {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '2.5rem' }}>
         {/* YouTube Feature */}
         <div className={styles.card}>
-          <h2 className={styles.cardTitle}>KQED&#39;s Check, Please! Bay Area</h2>
+          <h2>KQED&#39;s Check, Please! Bay Area</h2>
           <div style={{ maxWidth: 560, margin: '0 auto' }}>
             <iframe
               width="560"
@@ -56,7 +56,7 @@ export default function Press() {
         </div>
         {/* Instagram Feature */}
         <div className={styles.card}>
-          <h2 className={styles.cardTitle}>Instagram Feature</h2>
+          <h2>Instagram Feature</h2>
           <div style={{ maxWidth: 320, margin: '0 auto' }}>
             <iframe
               src="https://www.instagram.com/p/DIjVR1iJWyM/embed"
@@ -71,7 +71,7 @@ export default function Press() {
         </div>
         {/* Fremont Bank Article */}
         <div className={styles.card}>
-          <h2 className={styles.cardTitle}>Fremont Bank: Partnership in Action</h2>
+          <h2>Fremont Bank: Partnership in Action</h2>
           <p style={{ margin: 0, fontSize: '0.95rem', color: '#666' }}>
             This 2020 article from Fremont Bank highlights Skillet&#39;z Cafe&#39;s founding story
             and community roots.
@@ -88,7 +88,7 @@ export default function Press() {
         </div>
         {/* Community Resilience Section */}
         <div className={styles.card}>
-          <h2 className={styles.cardTitle}>Community Resilience: March 2024 Burglary</h2>
+          <h2>Community Resilience: March 2024 Burglary</h2>
           <p style={{ margin: 0, fontSize: '0.95rem', color: '#666' }}>
             In March 2024, Skillet&#39;z Cafe was burglarized. We are grateful for the outpouring of
             support from our community and the coverage from local media.

--- a/src/pages/press.tsx
+++ b/src/pages/press.tsx
@@ -41,7 +41,7 @@ export default function Press() {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '2.5rem' }}>
         {/* YouTube Feature */}
         <div className={styles.card}>
-          <h3 className={styles.cardTitle}>KQED&#39;s Check, Please! Bay Area</h3>
+          <h2 className={styles.cardTitle}>KQED&#39;s Check, Please! Bay Area</h2>
           <div style={{ maxWidth: 560, margin: '0 auto' }}>
             <iframe
               width="560"
@@ -56,7 +56,7 @@ export default function Press() {
         </div>
         {/* Instagram Feature */}
         <div className={styles.card}>
-          <h3 className={styles.cardTitle}>Instagram Feature</h3>
+          <h2 className={styles.cardTitle}>Instagram Feature</h2>
           <div style={{ maxWidth: 320, margin: '0 auto' }}>
             <iframe
               src="https://www.instagram.com/p/DIjVR1iJWyM/embed"
@@ -71,7 +71,7 @@ export default function Press() {
         </div>
         {/* Fremont Bank Article */}
         <div className={styles.card}>
-          <h3 className={styles.cardTitle}>Fremont Bank: Partnership in Action</h3>
+          <h2 className={styles.cardTitle}>Fremont Bank: Partnership in Action</h2>
           <p style={{ margin: 0, fontSize: '0.95rem', color: '#666' }}>
             This 2020 article from Fremont Bank highlights Skillet&#39;z Cafe&#39;s founding story
             and community roots.
@@ -88,7 +88,7 @@ export default function Press() {
         </div>
         {/* Community Resilience Section */}
         <div className={styles.card}>
-          <h3 className={styles.cardTitle}>Community Resilience: March 2024 Burglary</h3>
+          <h2 className={styles.cardTitle}>Community Resilience: March 2024 Burglary</h2>
           <p style={{ margin: 0, fontSize: '0.95rem', color: '#666' }}>
             In March 2024, Skillet&#39;z Cafe was burglarized. We are grateful for the outpouring of
             support from our community and the coverage from local media.

--- a/src/styles/Blog.module.css
+++ b/src/styles/Blog.module.css
@@ -25,7 +25,7 @@
   text-align: center;
 }
 
-.tagsContainer h3 {
+.tagsContainer h2 {
   margin-bottom: 1rem;
   color: var(--text-color);
   font-size: 1.1rem;

--- a/src/styles/BlogPost.module.css
+++ b/src/styles/BlogPost.module.css
@@ -114,7 +114,7 @@
   border: 1px solid var(--border-color);
 }
 
-.postTags h3 {
+.postTags h2 {
   margin-bottom: 1rem;
   color: var(--text-color);
   font-size: 1.1rem;

--- a/src/styles/Layout.module.css
+++ b/src/styles/Layout.module.css
@@ -188,7 +188,7 @@
   line-height: 2;
 }
 
-.footerSection h3 {
+.footerSection h2 {
   color: var(--footer-heading);
   margin-bottom: 0.5rem;
   transition: color var(--theme-transition-duration) var(--theme-transition-timing);


### PR DESCRIPTION
## Summary
- fix Nu HTML validator failures from Proof HTML
- remove redundant invalid `aria-label` attributes from generic visible-text menu elements
- use non-skipping heading levels for footer/blog/press sections
- add a custom 404 page so exported 404 HTML validates cleanly

## Testing
- `npx prettier --check` on changed files
- `npm run lint`
- `make build`
- local generated HTML inspection for previous Proof HTML failure classes: invalid `aria-label` on generic elements, skipped heading levels, and 404 style-tag placement

## Notes
- `npm run format:check` currently fails on pre-existing `AGENTS.md` formatting on `master`; this PR does not touch that file
- existing lint warnings for `<img>` usage are pre-existing and unchanged
