### PR TITLE
Update menu data from Toast export

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           directory: ./docs
           check_css: false
-          ignore_url_re: '(instagram\.com|facebook\.com|yelp\.com|yelp\.to|tripadvisor\.com|toasttab\.com|kron4\.com)'
+          ignore_url_re: '(instagram\.com|facebook\.com|yelp\.com|yelp\.to|tripadvisor\.com|toasttab\.com|doordash\.com|kron4\.com)'
           validator_ignore: 'Element.*style.*not allowed as child of element.*div.*in this context.*'

--- a/src/data/menu/image_mappings.json
+++ b/src/data/menu/image_mappings.json
@@ -1,7 +1,7 @@
 {
   "item_images": {},
   "metadata": {
-    "last_updated": "2026-03-19",
+    "last_updated": "2026-05-13",
     "version": "1.0",
     "image_root": "/images/menu/hd"
   }

--- a/src/data/menu/processed/menu.json
+++ b/src/data/menu/processed/menu.json
@@ -21,14 +21,14 @@
               "name": "Carne Asada Chilaquiles Rojos",
               "guid": "3a9acb98-7b01-492d-86a2-f7aa1423777c",
               "description": "Carne asada, tortilla chips, potatoes, red salsa, avocado, with choice of eggs. Available Saturdays!",
-              "price": 21.95,
+              "price": 22.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000000477030608_1742080390.jpg"
             },
             {
               "name": "Carne Asada Chilaquiles Verdes",
               "guid": "d6f3c062-38e5-4d20-8e55-41c8e8fab038",
               "description": "Carne asada, tortilla chips, potatoes, green salsa, avocado, with choice of eggs. Available Sundays!",
-              "price": 21.95,
+              "price": 22.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000000621744735_1737920176.jpg"
             },
             {
@@ -88,10 +88,10 @@
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000000352031880_1734993057.jpg"
             },
             {
-              "name": "Filet Mignon & Eggs w Mushrooms & Onions",
+              "name": "Porter house steak",
               "guid": "fbc8415d-055a-4e56-b76f-93f8f1815c29",
               "description": "",
-              "price": 31.95,
+              "price": 32.95,
               "imageUrl": null
             }
           ]
@@ -462,7 +462,7 @@
               "name": "New York Steak & Eggs",
               "guid": "c88faf5d-053f-41d3-9577-f716b8628e38",
               "description": "New York strip steak, eggs.",
-              "price": 22.95,
+              "price": 23.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000000352423356_1734992872.jpg"
             },
             {
@@ -770,7 +770,7 @@
               "name": "Skillet'z Special",
               "guid": "c97ef511-56b5-450d-8b0b-1da334259c84",
               "description": "2 pancakes, 2 French toast, or 1 waffle choice of sausage or bacon and two eggs.",
-              "price": 15.95,
+              "price": 16.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000000352916859_1735408724.jpg"
             },
             {
@@ -1173,10 +1173,10 @@
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000000352031880_1734993057.jpg"
             },
             {
-              "name": "Filet Mignon & Eggs w Mushrooms & Onions",
+              "name": "Porter house steak",
               "guid": "fbc8415d-055a-4e56-b76f-93f8f1815c29",
               "description": "",
-              "price": 31.95,
+              "price": 32.95,
               "imageUrl": null
             }
           ]
@@ -1547,7 +1547,7 @@
               "name": "New York Steak & Eggs",
               "guid": "c88faf5d-053f-41d3-9577-f716b8628e38",
               "description": "New York strip steak, eggs.",
-              "price": 22.95,
+              "price": 23.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000000352423356_1734992872.jpg"
             },
             {
@@ -1855,7 +1855,7 @@
               "name": "Skillet'z Special",
               "guid": "c97ef511-56b5-450d-8b0b-1da334259c84",
               "description": "2 pancakes, 2 French toast, or 1 waffle choice of sausage or bacon and two eggs.",
-              "price": 15.95,
+              "price": 16.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000000352916859_1735408724.jpg"
             },
             {
@@ -2205,14 +2205,14 @@
               "name": "Carne Asada Chilaquiles Rojos",
               "guid": "3a9acb98-7b01-492d-86a2-f7aa1423777c",
               "description": "Carne asada, tortilla chips, potatoes, red salsa, avocado, with choice of eggs. Available Saturdays!",
-              "price": 21.95,
+              "price": 22.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000000477030608_1742080390.jpg"
             },
             {
               "name": "Carne Asada Chilaquiles Verdes",
               "guid": "d6f3c062-38e5-4d20-8e55-41c8e8fab038",
               "description": "Carne asada, tortilla chips, potatoes, green salsa, avocado, with choice of eggs. Available Sundays!",
-              "price": 21.95,
+              "price": 22.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000000621744735_1737920176.jpg"
             },
             {
@@ -2272,10 +2272,10 @@
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000000352031880_1734993057.jpg"
             },
             {
-              "name": "Filet Mignon & Eggs w Mushrooms & Onions",
+              "name": "Porter house steak",
               "guid": "fbc8415d-055a-4e56-b76f-93f8f1815c29",
               "description": "",
-              "price": 31.95,
+              "price": 32.95,
               "imageUrl": null
             }
           ]
@@ -2646,7 +2646,7 @@
               "name": "New York Steak & Eggs",
               "guid": "c88faf5d-053f-41d3-9577-f716b8628e38",
               "description": "New York strip steak, eggs.",
-              "price": 22.95,
+              "price": 23.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000000352423356_1734992872.jpg"
             },
             {
@@ -2954,7 +2954,7 @@
               "name": "Skillet'z Special",
               "guid": "c97ef511-56b5-450d-8b0b-1da334259c84",
               "description": "2 pancakes, 2 French toast, or 1 waffle choice of sausage or bacon and two eggs.",
-              "price": 15.95,
+              "price": 16.95,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000000352916859_1735408724.jpg"
             },
             {
@@ -3327,6 +3327,13 @@
               "description": "",
               "price": 5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000000383737778_1735494293.jpg"
+            },
+            {
+              "name": "Cheese Fries 🧀🍟",
+              "guid": "44b0dde3-be60-4a23-9744-9d884ee1ef9c",
+              "description": "",
+              "price": 5,
+              "imageUrl": null
             }
           ]
         },
@@ -3454,6 +3461,20 @@
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000000353183280_1734991647.jpg"
             },
             {
+              "name": "Skillet'z Chef's Salad",
+              "guid": "9727114f-d5f1-442e-9102-5b6436e84c39",
+              "description": "",
+              "price": 18.95,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000009756718547_1774134751.jpg"
+            },
+            {
+              "name": "Steak Salad",
+              "guid": "ad8c8430-d64d-4483-95e8-0f81cbe869bc",
+              "description": "",
+              "price": 22.95,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000009756718549_1774134759.jpg"
+            },
+            {
               "name": "Side Salad",
               "guid": "26f99c48-aab7-4142-9ff1-0f7538bfb410",
               "description": "",
@@ -3494,6 +3515,34 @@
               "description": "7oz ground chicken patty, swiss cheese, bacon, avocado, lettuce, tomatoes, onions, pickles. Served with a side of french fries.",
               "price": 16,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000002960554986_1749359726.jpg"
+            },
+            {
+              "name": "Hawaiian Burger",
+              "guid": "085d864f-f8c4-4093-bf32-16434b6d9cf5",
+              "description": "",
+              "price": 18.95,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000009756511291_1774134634.jpg"
+            },
+            {
+              "name": "Smash Burger",
+              "guid": "f45dfb4e-8fbd-4875-9f39-346c787135f2",
+              "description": "",
+              "price": 16.95,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000009756511293_1774134646.jpg"
+            },
+            {
+              "name": "Cowboy Burger",
+              "guid": "960bdf9e-e824-436d-bf0e-ef0d53c8d07f",
+              "description": "",
+              "price": 18.95,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000009756511295_1774134659.jpg"
+            },
+            {
+              "name": "Spicy Crispy Chicken Burger",
+              "guid": "b9bbfc33-fad6-4345-a146-6c39719b77fe",
+              "description": "",
+              "price": 18.95,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000009756511297_1774134671.jpg"
             }
           ]
         },
@@ -4082,95 +4131,151 @@
           "description": "",
           "items": [
             {
-              "name": "Tiger Milk with Boba 🐯🌙",
+              "name": "41 Tiger Milk with Boba 🐯🌙",
               "guid": "397c74f4-dd53-42ab-8d93-547792bb6f31",
               "description": "Fresh milk with handcrafted top grade brown sugar stripes — rich, creamy, and naturally caffeine-free 🌙 Served with boba. Our tapioca boba is made from scratch in Hayward with simple ingredients — no preservatives.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000004994025826_1766999024.png"
             },
             {
-              "name": "Vietnamese Iced Coffee 🇻🇳❄️☕️",
+              "name": "81 Vietnamese Iced Coffee 🇻🇳❄️☕️",
               "guid": "4a43aa3b-d998-4133-b4e4-1f5f09e28cd5",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000006208598079_1766829504.png"
             },
             {
-              "name": "Crème Brûlée Vietnamese Iced Coffee",
+              "name": "82 Crème Brûlée Vietnamese Iced Coffee",
               "guid": "77529224-ee41-4ca5-af0d-fd7abe5d4e8c",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans ☕❄ +  Crème Brûlée 🍮",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000005291458123_1766840134.png"
             },
             {
-              "name": "Mango Jasmine Green Tea with Mango Star Jelly 🥭⭐️",
+              "name": "Mango Jasmine Tea w/ Mango Star Jelly 🥭⭐️",
               "guid": "9b1893d1-b802-4f64-9ffe-d9fc0ed20015",
               "description": "Fragrant jasmine green tea brightened with juicy mango and fun star-shaped jelly.",
               "price": 7.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004993398070_1757106176.jpg"
             },
             {
-              "name": "Dino Freeze 🍓🥭🍑🦖❄️🌙",
+              "name": "75 Dino Freeze 🍓🥭🍑🦖❄️🌙",
               "guid": "f65e8ad8-357e-4cac-be70-685d9dc414c8",
               "description": "A frosty slush of your choices of real fruit purees blended into the ultimate sweet chill.",
               "price": 6.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/ee481775-1408-4e3a-9574-5b1dfc8958fa.png"
             },
             {
-              "name": "Lychee Jasmine Green",
+              "name": "51 Lychee Jasmine Green",
               "guid": "2a564dd9-bfdf-4478-af12-e9a2f6f961cd",
               "description": "jasmine green tea + lychee puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Mango Passionfruit Jasmine Green",
+              "name": "53 Mango Passionfruit Jasmine Green",
               "guid": "39403e9a-36da-4187-9d3b-3ceb1fe5cf53",
               "description": "jasmine green tea + mango and passionfruit puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Ube Taro Milk with Boba 🍠🍯🌙",
-              "guid": "694b51e6-58d9-4fea-9505-b159610b2d91",
-              "description": "Made with real taro and ube, without artificial colors or flavors.",
-              "price": 8.25,
-              "imageUrl": null
-            },
-            {
-              "name": "Mango Grapefruit Crystal 🥭🥥💎(🌙)",
+              "name": "74 Mango Grapefruit Crystal 🥭🥥💎(🌙)",
               "guid": "47908528-b0f5-4977-ae65-e72fdfb14edc",
               "description": "organic mangos, jasmine tea, organic coconut milk, grapefruit pulp and crystal boba",
               "price": 8.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000005355541035_1770463715.png"
             },
             {
-              "name": "Strawberry Lemonade 🍓🍋🌙",
+              "name": "62 Strawberry Lemonade 🍓🍋🌙",
               "guid": "a139d893-5fd8-41b1-8cfc-75a414b02ce9",
               "description": "Made to order with fresh lemons, cane sugar, strawberry puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/f885eb1f-5056-4f95-aac5-388e287932b4.png"
             },
             {
-              "name": "Assam Black Milk Tea with Boba 🧋🍯",
-              "guid": "e53f98bd-b769-472f-8eee-a9d974f2f0bf",
-              "description": "Bold and malty Assam black tea swirled with creamy milk and chewy boba.",
-              "price": 7.5,
-              "imageUrl": null
-            },
-            {
-              "name": "Strawberry Matcha Latte 🍓🍵",
+              "name": "33 Strawberry Matcha Latte 🍓🍵",
               "guid": "9f638a67-3997-4db2-892a-1a94f2f0d8fb",
               "description": "Top grade Japanese Royal matcha, organic strawberries",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/e7b9194f-b34e-4fe4-9661-22e8a6f3443e.png"
             },
             {
-              "name": "Crème Brûlée Tiger Milk (with Boba) 🌙",
+              "name": "42 Crème Brûlée Tiger Milk (with Boba) 🌙",
               "guid": "0c7bad54-8207-4bbd-9501-f8e71823a4ec",
               "description": "",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000008087959751_1768258758.png"
+            }
+          ]
+        },
+        {
+          "name": "🆕 Tea-Rek’z Signatures 🦖",
+          "guid": "eb79ad18-9f60-4a3d-bcc2-61b6f67b9082",
+          "description": "Featuring rare drinks like our cold brewed magnolia green tea creations, fresh cream toppings made without artificial creamers, and all-natural fruit ingredients for a cleaner, more premium drink experience.",
+          "items": [
+            {
+              "name": "S1 Magnolia Cloud",
+              "guid": "ef9f74db-5f45-412a-9451-5ffee16b85c3",
+              "description": "Magnolia Green Tea with Jasmine Cream. Best enjoyed without boba.",
+              "price": 7.5,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/19c63b47-b769-4dc8-b248-f3c071e3a731.png"
+            },
+            {
+              "name": "S2 Magnolia Velvet",
+              "guid": "c3832cb2-69af-45c7-8cb3-1bf38ba123c3",
+              "description": "Magnolia Green Tea with Sea Salt Cheese Cream. Best enjoyed without boba.",
+              "price": 7.5,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000011091561172_1778489973.png"
+            },
+            {
+              "name": "S3 Magnolia Matcha Cloud",
+              "guid": "d7e18553-ed9e-4048-bfb2-7c61465b9c93",
+              "description": "Magnolia Green Tea with Matcha Cream. Best enjoyed without boba.",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000011091561174_1778490002.png"
+            },
+            {
+              "name": "S4 Magnolia Orchard",
+              "guid": "be2f0cab-d4fe-4f70-bba6-951c8435f2fa",
+              "description": "Lychee and Peach Magnolia Green Tea with Jasmine Cream. Best enjoyed without boba.",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/6a335c51-2baf-4041-95b6-ce57dcf4cc73.png"
+            },
+            {
+              "name": "S5 Lychee Blossom",
+              "guid": "0da520c1-3aa2-4b8a-8ae6-1897e83b09ad",
+              "description": "Lychee Jasmine Green Tea with Jasmine Cream",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000011091561178_1778490072.png"
+            },
+            {
+              "name": "S6 Pistachio Cream Coffee",
+              "guid": "f5ad4454-05d8-45f8-848a-a9ad018d5045",
+              "description": "Vietnamese Iced Coffee with Pistachio Cream",
+              "price": 8,
+              "imageUrl": null
+            },
+            {
+              "name": "S7 Matcha Blossom",
+              "guid": "d454ff49-5c40-4dab-a3d8-4d7118b8e057",
+              "description": "Matcha Latte with Raspberry Cream",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000011091561182_1778490107.jpg"
+            },
+            {
+              "name": "S8 Strawberry Pop Milk",
+              "guid": "9afbd0f0-4641-4db4-a981-5e2bab4aa0fa",
+              "description": "Organic strawberries, fresh milk, and naturally colored strawberry popping boba",
+              "price": 7.5,
+              "imageUrl": null
+            },
+            {
+              "name": "S9 Mango Pop Milk",
+              "guid": "c11fa717-2877-4b32-a43d-fe7bce021e36",
+              "description": "Organic mango, fresh milk, and naturally colored mango popping boba",
+              "price": 7.5,
+              "imageUrl": null
             }
           ]
         },
@@ -4180,63 +4285,35 @@
           "description": "Freshly brewed with purified mineral water.",
           "items": [
             {
-              "name": "Jasmine Green Tea",
+              "name": "1 Jasmine Green Tea",
               "guid": "6636abcc-be69-4fe1-9fd1-85b03e597b55",
               "description": "",
               "price": 5.75,
               "imageUrl": null
             },
             {
-              "name": "Lychee Black Tea",
+              "name": "2 Magnolia Green Tea",
+              "guid": "1c375b46-e404-4632-9428-f5914ae23cf4",
+              "description": "Cold brewed green tea scented with magnolia flowers for a smooth, floral, naturally sweet, zero-bitterness finish.",
+              "price": 6,
+              "imageUrl": null
+            },
+            {
+              "name": "3 Lychee Black Tea",
               "guid": "cc2821e8-c4f0-4d80-8bc7-0f59fbfa37d9",
               "description": "A fragrant black tea with natural lychee aroma, smooth and floral with a subtle fruity finish. Refreshing on its own, without added sweetness.",
               "price": 5.75,
               "imageUrl": null
             },
             {
-              "name": "Earl Grey Tea",
-              "guid": "51b2111a-ac9c-4547-92af-c515197c8b1f",
-              "description": "Bold black tea infused with fragrant bergamot citrus for a smooth, aromatic finish.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "White Peach Oolong Tea",
+              "name": "4 White Peach Oolong Tea",
               "guid": "85a64a76-cc44-4db5-b85c-47314a48cdda",
               "description": "A smooth, floral oolong with a natural white peach aroma. Light and refreshing with a subtle fruit fragrance, not sweet on its own.",
-              "price": 5.75,
+              "price": 6,
               "imageUrl": null
             },
             {
-              "name": "White Grape Oolong Tea",
-              "guid": "d6349841-dc34-4eeb-b256-4c8c037739d9",
-              "description": "A fragrant oolong with the delicate aroma of white grapes. Crisp and refreshing, smooth and floral, not sweet on its own.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "Four Seasons Jade Oolong",
-              "guid": "e9224a1d-12a8-4591-b3a4-7bc2b98604de",
-              "description": "A lightly roasted Taiwanese oolong with a bright, floral aroma and smooth, refreshing finish. Balanced between green and oolong, it’s crisp yet delicate.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "High Mountain Oolong",
-              "guid": "00d8e850-86e2-4116-9736-d4c992d74204",
-              "description": "Cold brewed for a smooth, naturally creamy cup with a clean finish.\r\nLight sweetness recommended — extra sugar will overpower the tea.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "High Mountain Jasmine",
-              "guid": "ca5d6b9e-1e5f-4b61-9f8a-046517f3bd84",
-              "description": "A blend of High Mountain Oolong and Jasmine Green Tea. Cold brewed for a smooth, naturally creamy cup with a clean finish.\r\nLight sweetness recommended — extra sugar will overpower the tea.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "Rooibos Tea 🌙",
+              "name": "5 Rooibos Tea 🌙",
               "guid": "47d3cd45-c531-4553-a20a-7054195b565b",
               "description": "Naturally caffeine-free 🌙 herbal tea from South Africa, with a smooth, earthy flavor and gentle notes of honey and vanilla.",
               "price": 5.75,
@@ -4247,77 +4324,70 @@
         {
           "name": "Milk Teas 🧋",
           "guid": "f331262f-fcdf-400a-9ef7-57d51d47a412",
-          "description": "",
+          "description": "Rich, creamy, and bold tea-forward milk teas",
           "items": [
             {
-              "name": "Jasmine Green Milk Tea",
-              "guid": "0f1c0cab-e4aa-4019-86d5-17941569a927",
-              "description": "Fragrant, floral, and refreshing with a light creamy finish.",
-              "price": 6.75,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004992513670_1766830576.png"
-            },
-            {
-              "name": "Jasmine Milk Tea with Matcha Cream",
-              "guid": "18895557-c944-4f3f-87d5-da0bd143b504",
-              "description": "Jasmine milk tea topped with matcha cream",
-              "price": 8.25,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000008087703153_1768259982.png"
-            },
-            {
-              "name": "Lychee Black Milk Tea",
+              "name": "21 Lychee Black Milk Tea",
               "guid": "6fd9f266-9d5e-44aa-8284-665b1b5e52fd",
               "description": "Smooth black tea with a natural lychee fragrance, blended with creamy milk for a floral, subtly fruity cup. Light and aromatic, not sweet on its own.",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Assam Black Milk Tea",
+              "name": "22 Assam Black Milk Tea",
               "guid": "e41b7556-b795-4f70-b6c8-4ffbd9773bba",
               "description": "Bold, malty, and robust — the classic milk tea taste.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004994025820_1766831402.png"
             },
             {
-              "name": "Ceylon Milk Tea",
-              "guid": "df24d483-c541-4a25-8340-38a071c83e89",
-              "description": "Bold, malty, and robust — the classic milk tea taste.",
-              "price": 6.75,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004994025820_1766831402.png"
-            },
-            {
-              "name": "Roasted Oolong Milk Tea",
+              "name": "23 Roasted Oolong Milk Tea",
               "guid": "e6851d44-4c4d-4cbd-a394-bdb066872406",
               "description": "Toasty, nutty, and smooth with balanced depth.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000004994025822_1757106082.jpg"
             },
             {
-              "name": "Classic Thai Tea 🇹🇭🫖",
+              "name": "24 Classic Thai Tea 🇹🇭🫖",
               "guid": "5b5e969a-bf1d-44f2-a67c-69fd5f704731",
               "description": "Bold, spiced Thai black tea layered with organic half & half — smooth, rich, and served at fixed sweetness.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004994025830_1766817442.png"
             },
             {
-              "name": "Crème Brûlée Classic Thai Tea",
+              "name": "25 Crème Brûlée Classic Thai Tea",
               "guid": "6a9c1c33-4329-4399-9279-7eddcb70cfcb",
               "description": "Classic Thai Tea + Crème Brûlée",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000005291465641_1772013526.jpg"
             },
             {
-              "name": "White Peach Oolong Milk Tea",
-              "guid": "247193a1-42f6-4dc0-a41a-7cb4776981f6",
-              "description": "",
-              "price": 6.75,
-              "imageUrl": null
-            },
-            {
-              "name": "Assam Masala Chai Tea 🇮🇳☕",
+              "name": "26 Assam Masala Chai Tea 🇮🇳☕",
               "guid": "dabb98d5-def4-49d1-9b7b-b8e392114945",
               "description": "Bold Assam black tea with aromatic Indian spices — smooth, spicy, and deeply comforting.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/4627b8d1-96ae-4f78-aefe-50e9491d6f55.jpg"
+            },
+            {
+              "name": "27 Jasmine Green Milk Tea",
+              "guid": "0f1c0cab-e4aa-4019-86d5-17941569a927",
+              "description": "Fragrant, floral, and refreshing with a light creamy finish.",
+              "price": 6.75,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004992513670_1766830576.png"
+            },
+            {
+              "name": "28 White Peach Oolong Milk Tea",
+              "guid": "ac06f7df-2155-4d3a-af8d-6e0f8faaa0f9",
+              "description": "Fragrant oolong tea with a delicate white peach aroma, blended with creamy milk for a smooth, floral, and subtly fruity taste. Naturally not sweet on its own.",
+              "price": 7,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000005129626884_1757235096.jpg"
+            },
+            {
+              "name": "29 Rooibos Milk Tea🌙",
+              "guid": "b694a634-dfb5-40fb-a28a-accf27351324",
+              "description": "Naturally caffeine-free rooibos blended with creamy milk for a smooth, earthy cup with gentle notes of honey and vanilla.",
+              "price": 6.75,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000005129626888_1757235175.jpg"
             }
           ]
         },
@@ -4327,49 +4397,42 @@
           "description": "Made with royal Japanese matcha and fresh milk.",
           "items": [
             {
-              "name": "Matcha Latte 🍵",
+              "name": "31 Matcha Latte 🍵",
               "guid": "38020157-0819-4e45-bda3-b1f8e98e6bd7",
               "description": "Top grade Japanese Royal matcha",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/e1fd77d1-e1a7-4ad7-98f2-36e884cc4e69.png"
             },
             {
-              "name": "Brown Sugar Matcha Latte 🍵",
+              "name": "32 Brown Sugar Matcha Latte 🍵",
               "guid": "5cf93bf6-076d-418d-b601-a55609743f40",
               "description": "Top grade Japanese Royal matcha and handcrafted top grade brown sugar.",
               "price": 7.25,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000005129736630_1766830179.png"
             },
             {
-              "name": "Strawberry Matcha Latte 🍓🍵",
+              "name": "33 Strawberry Matcha Latte 🍓🍵",
               "guid": "9f638a67-3997-4db2-892a-1a94f2f0d8fb",
               "description": "Top grade Japanese Royal matcha, organic strawberries",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/e7b9194f-b34e-4fe4-9661-22e8a6f3443e.png"
             },
             {
-              "name": "Mango Matcha Latte 🥭🍵",
+              "name": "34 Mango Matcha Latte 🥭🍵",
               "guid": "1124c118-18f6-4148-aefe-bdaccf56313f",
               "description": "Top grade Japanese Royal matcha, organic mangos",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/a9066480-ceea-44c8-b5d2-44b07892385e.png"
             },
             {
-              "name": "Taro Matcha Latte 🍠🍵",
+              "name": "35 Taro Matcha Latte 🍠🍵",
               "guid": "c4924a80-f3da-4e0e-bd6c-406f21853eae",
               "description": "Top grade Japanese Royal matcha, real taro and ube.",
               "price": 8.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000008109510341_1772013412.jpg"
             },
             {
-              "name": "Double Matcha 🍵🍵",
-              "guid": "07287a93-4d37-4d87-9e67-5d4762badc83",
-              "description": "Matcha Milk Tea with Matcha Cream",
-              "price": 8.5,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000008087662787_1768259398.jpg"
-            },
-            {
-              "name": "Dalgona Matcha Latte 🍯🍵",
+              "name": "36 Dalgona Matcha Latte 🍯🍵",
               "guid": "4a78efb8-8262-4ec5-a583-083c33d7793a",
               "description": "Creamy matcha with honeycomb toffee-like dalgona crumbles for a sweet, toasty crunch, inspired by the Korean street treat in Squid Game.",
               "price": 7.5,
@@ -4383,56 +4446,42 @@
           "description": "",
           "items": [
             {
-              "name": "Tiger Milk with Boba 🐯🌙",
+              "name": "41 Tiger Milk with Boba 🐯🌙",
               "guid": "397c74f4-dd53-42ab-8d93-547792bb6f31",
               "description": "Fresh milk with handcrafted top grade brown sugar stripes — rich, creamy, and naturally caffeine-free 🌙 Served with boba. Our tapioca boba is made from scratch in Hayward with simple ingredients — no preservatives.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000004994025826_1766999024.png"
             },
             {
-              "name": "Crème Brûlée Tiger Milk (with Boba) 🌙",
+              "name": "42 Crème Brûlée Tiger Milk (with Boba) 🌙",
               "guid": "0c7bad54-8207-4bbd-9501-f8e71823a4ec",
               "description": "",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000008087959751_1768258758.png"
             },
             {
-              "name": "Assam Tiger Milk with Boba 🐯",
-              "guid": "147bff69-088e-4b37-9ca6-8b7a7ca06701",
-              "description": "Our signature Tiger Milk infused with a subtle layer of Assam black tea. Milk-forward, caramel-rich, with just a whisper of malty depth.",
-              "price": 8,
-              "imageUrl": null
-            },
-            {
-              "name": "Jasmine Tiger Milk with Boba 🐯",
-              "guid": "d8f82863-c65b-48c0-9ad8-9329ab8ae84d",
-              "description": "Our signature Tiger Milk layered with a subtle jasmine tea essence. Silky, fragrant, and softly floral.",
-              "price": 8,
-              "imageUrl": null
-            },
-            {
-              "name": "Ube Taro Milk 🍠🌙",
+              "name": "43 Ube Taro Milk 🍠🌙",
               "guid": "29ed0bdd-c183-4b76-8a6e-0b9861d806e9",
               "description": "Real taro and real Ube blended with milk — naturally creamy, with no artificial colors or flavors.",
               "price": 7.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000004994025832_1766816106.png"
             },
             {
-              "name": "Strawberry Milk 🍓🥛🌙",
+              "name": "44 Strawberry Milk 🍓🥛🌙",
               "guid": "6d16adff-8a04-4f07-a599-ae2645ce50a5",
               "description": "organic strawberries and fresh milk",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000008620469457_1770420574.png"
             },
             {
-              "name": "Korean Mango Milk 🥭🥛🌙",
+              "name": "45 Korean Mango Milk 🥭🥛🌙",
               "guid": "50f1ea8a-b89b-4c45-be62-b15826e553b2",
               "description": "organic mango and fresh milk",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000009018273524_1772013435.jpg"
             },
             {
-              "name": "Horchata de Avena 🍂🥛🌙",
+              "name": "46 Horchata de Avena 🍂🥛🌙",
               "guid": "b32f9dfb-6c88-44f4-b91a-69d12e08ff0e",
               "description": "oat milk horchata",
               "price": 7,
@@ -4446,28 +4495,35 @@
           "description": "",
           "items": [
             {
-              "name": "Lychee Jasmine Green",
+              "name": "51 Lychee Jasmine Green",
               "guid": "2a564dd9-bfdf-4478-af12-e9a2f6f961cd",
               "description": "jasmine green tea + lychee puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Strawberry Peach Jade Oolong",
+              "name": "52 Strawberry Peach Jade Oolong",
               "guid": "fea5b79b-9c7e-42e6-b860-960a218b071e",
               "description": "freshly brewed four seasons jade oolong + strawberry and peach puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Mango Passionfruit Jasmine Green",
+              "name": "53 Mango Passionfruit Jasmine Green",
               "guid": "39403e9a-36da-4187-9d3b-3ceb1fe5cf53",
               "description": "jasmine green tea + mango and passionfruit puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Build Your Own Fruit Tea  🍓🌱",
+              "name": "54 Peach Lychee Magnolia Green",
+              "guid": "999648d8-5a23-46d5-826e-78626e6891a9",
+              "description": "",
+              "price": 7,
+              "imageUrl": null
+            },
+            {
+              "name": "55 Build Your Own Fruit Tea  🍓🌱",
               "guid": "81bebd73-204d-4c9e-b333-07c85946cae1",
               "description": "",
               "price": 6.75,
@@ -4481,49 +4537,49 @@
           "description": "",
           "items": [
             {
-              "name": "Lemonade 🍋🌙",
+              "name": "61 Lemonade 🍋🌙",
               "guid": "19c3f8bd-1fc8-41f9-a148-5ed5334b3513",
               "description": "Made to order with fresh lemons, cane sugar, and purified mineral water — never pre-made.",
               "price": 6,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000005291429206_1766827502.png"
             },
             {
-              "name": "Strawberry Lemonade 🍓🍋🌙",
+              "name": "62 Strawberry Lemonade 🍓🍋🌙",
               "guid": "a139d893-5fd8-41b1-8cfc-75a414b02ce9",
               "description": "Made to order with fresh lemons, cane sugar, strawberry puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/f885eb1f-5056-4f95-aac5-388e287932b4.png"
             },
             {
-              "name": "Mango Lemonade 🥭🍋🌙",
+              "name": "63 Mango Lemonade 🥭🍋🌙",
               "guid": "21e5141b-a3ec-4df9-a367-7d0aa7b9ea2a",
               "description": "Made to order with fresh lemons, cane sugar, mango puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000005355804257_1758274181.jpg"
             },
             {
-              "name": "Passionfruit Lemonade 🍋🌙",
+              "name": "64 Passionfruit Lemonade 🍋🌙",
               "guid": "eb3d2a9c-ae85-4319-b895-688a8b8f3f1b",
               "description": "Made to order with fresh lemons, cane sugar, passionfruit puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000005355808498_1758274196.jpg"
             },
             {
-              "name": "Purple Lemonade 🔮🍋🌙",
+              "name": "65 Purple Lemonade 🔮🍋🌙",
               "guid": "38106a34-9d29-4d18-a28c-2e4cda6143bd",
               "description": "A color-changing twist of fresh lemonade + passionfruit, and butterfly pea tea — bright, tangy, and magically purple! 🦖🍋💜✨",
               "price": 7.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000006111297916_1766828237.png"
             },
             {
-              "name": "Rose Hibiscus Lemonade 🌹🌺🍋🌙",
+              "name": "66 Rose Hibiscus Lemonade 🌹🌺🍋🌙",
               "guid": "04963db2-a9f9-4908-8fcd-5f28fdd2b0b8",
               "description": "",
               "price": 7,
               "imageUrl": null
             },
             {
-              "name": "Ginger Lemonade 🫚🍋🌙",
+              "name": "67 Ginger Lemonade 🫚🍋🌙",
               "guid": "a23a33e3-a783-4542-9622-4380aeb4b987",
               "description": "Made to order with fresh lemons, cane sugar, ginger puree and purified mineral water — never pre-made.",
               "price": 7,
@@ -4537,35 +4593,35 @@
           "description": "",
           "items": [
             {
-              "name": "Golden Mango 🥭🌙",
+              "name": "71 Golden Mango 🥭🌙",
               "guid": "5e3df891-b445-4aff-b828-a18665436d43",
               "description": "Over half a pound organic mangos + golden cane sugar + purified mineral water.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000007709137801_1770463661.png"
             },
             {
-              "name": "Jasmine Mango 🫖🥭",
+              "name": "72 Jasmine / Magnolia Mango 🫖🥭",
               "guid": "6c07b946-0cf5-4384-8c46-5ad9a70f5fdc",
               "description": "Over half a pound organic mangos + golden cane sugar + jasmine tea.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000007709137803_1770463677.png"
             },
             {
-              "name": "Coco Mango 🥥🥭🌙",
+              "name": "73 Coco Mango 🥥🥭🌙",
               "guid": "b0212c8a-b50f-40a0-8ca7-f0d23d06d144",
               "description": "Over half a pound organic mangos + golden cane sugar + pistachios.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000007709137805_1770463698.png"
             },
             {
-              "name": "Mango Grapefruit Crystal 🥭🥥💎(🌙)",
+              "name": "74 Mango Grapefruit Crystal 🥭🥥💎(🌙)",
               "guid": "47908528-b0f5-4977-ae65-e72fdfb14edc",
               "description": "organic mangos, jasmine tea, organic coconut milk, grapefruit pulp and crystal boba",
               "price": 8.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000005355541035_1770463715.png"
             },
             {
-              "name": "Dino Freeze 🍓🥭🍑🦖❄️🌙",
+              "name": "75 Dino Freeze 🍓🥭🍑🦖❄️🌙",
               "guid": "f65e8ad8-357e-4cac-be70-685d9dc414c8",
               "description": "A frosty slush of your choices of real fruit purees blended into the ultimate sweet chill.",
               "price": 6.5,
@@ -4579,42 +4635,42 @@
           "description": "",
           "items": [
             {
-              "name": "Vietnamese Iced Coffee 🇻🇳❄️☕️",
+              "name": "81 Vietnamese Iced Coffee 🇻🇳❄️☕️",
               "guid": "4a43aa3b-d998-4133-b4e4-1f5f09e28cd5",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000006208598079_1766829504.png"
             },
             {
-              "name": "Crème Brûlée Vietnamese Iced Coffee",
+              "name": "82 Crème Brûlée Vietnamese Iced Coffee",
               "guid": "77529224-ee41-4ca5-af0d-fd7abe5d4e8c",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans ☕❄ +  Crème Brûlée 🍮",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000005291458123_1766840134.png"
             },
             {
-              "name": "Vietnamese Iced Coffee with Pistachio Cream",
+              "name": "83 Pistachio Cream Vietnamese Iced Coffee",
               "guid": "df813baf-d827-4490-8bb6-5f1f1b450f2f",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans ☕❄ +  Pistachio Cream.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000007709066774_1772013562.jpg"
             },
             {
-              "name": "Dino Fuel (Vietnamese Coffee x Thai Tea) 🇻🇳🇹🇭⚡️",
+              "name": "84 Dino Fuel (Vietnamese Coffee x Thai Tea) 🇻🇳🇹🇭⚡️",
               "guid": "a842bbf8-69e7-4683-a3de-69e8186c5b51",
               "description": "Also called \"Dirty Thai Tea\", smooth Thai milk tea blended with double shots of espresso for a perfect mix of sweetness, spice, and caffeine kick. Ice and sweetness level are fixed.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000006111243964_1766829653.png"
             },
             {
-              "name": "Dirty Horchata de Avena 🍂🥛☕️",
+              "name": "85 Dirty Horchata de Avena 🍂🥛☕️",
               "guid": "4e68814f-c46c-413f-914e-f259e35f0a40",
               "description": "Oat milk Horchata + Vietnamese coffee.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000008620842186_1770420855.png"
             },
             {
-              "name": "Vietnamese Mocha 🇻🇳🍫☕️",
+              "name": "86 Vietnamese Mocha 🇻🇳🍫☕️",
               "guid": "ca78141b-77ba-4f33-b5f9-b1b62b31abe9",
               "description": "Crafted with organic cocoa, fresh milk, and traditional butter-roasted Vietnamese coffee for a mocha that’s intense, velvety, and unforgettable.",
               "price": 8,
@@ -4628,35 +4684,35 @@
           "description": "",
           "items": [
             {
-              "name": "Hazelnut Hot Chocolate 🍫☕🌙",
+              "name": "91 Hazelnut Hot Chocolate 🍫☕🌙",
               "guid": "ed047973-c0cd-4bb7-8309-a6344a3260d4",
               "description": "Crafted with organic cocoa, fresh milk, and roasted hazelnut for a luxuriously smooth, deeply chocolatey experience.",
               "price": 6,
               "imageUrl": null
             },
             {
-              "name": "Jasmine Hot Chocolate 🍫☕🌙",
+              "name": "92 Jasmine Hot Chocolate 🍫☕🌙",
               "guid": "03c70935-3d44-46fc-91c5-e30104278a23",
               "description": "Deep organic cocoa meets a whisper of jasmine tea for a refined twist on classic hot chocolate — rich, smooth, and lightly floral.",
               "price": 7,
               "imageUrl": null
             },
             {
-              "name": "Masala Chai Hot Chocolate 🍫☕🌙",
+              "name": "93 Masala Chai Hot Chocolate 🍫☕🌙",
               "guid": "5e81bce7-e5b9-4773-9ec2-3b2dbd771a79",
               "description": "Organic cocoa blended with steamed milk, warm chai spices, and a subtle touch of Assam tea. Rich, aromatic, and gently spiced.",
               "price": 8,
               "imageUrl": null
             },
             {
-              "name": "Hot Honey Yuzu Tea 🍋🍯🌙",
+              "name": "94 Hot Honey Yuzu Tea 🍋🍯🌙",
               "guid": "1bf35892-edda-481c-b34c-e4628cc49ab4",
               "description": "A comforting blend of honey and yuzu citrus, served hot for a soothing, lightly sweet and tangy cup.",
               "price": 5,
               "imageUrl": null
             },
             {
-              "name": "Hot Ginger Honey Yuzu Tea 🍋🍯🫚🌙",
+              "name": "95 Hot Ginger Honey Yuzu Tea 🍋🍯🫚🌙",
               "guid": "c333b873-5dfe-40f7-9384-50cb1e38ed99",
               "description": "Fragrant yuzu citrus blended with honey and fresh ginger for a warm, soothing cup with bright citrus and gentle spice.",
               "price": 6,
@@ -4670,18 +4726,39 @@
           "description": "",
           "items": [
             {
-              "name": "Fresh Squeezed Orange Juice 🍊🌙",
+              "name": "98 Fresh Squeezed Orange Juice 🍊🌙",
               "guid": "d8f92398-3afc-40cb-94c0-201ef8540dcb",
               "description": "Our most loved fresh squeezed orange juice from Skillet'z in a boba cup!",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/db883614-824a-46fa-b18c-b285af488d7f.png"
             },
             {
-              "name": "Boba Sundae 🧋🍨🌙",
+              "name": "99 Boba Sundae 🧋🍨🌙",
               "guid": "66f34a9c-b1e2-469b-be05-94e120b77c9f",
               "description": "Two large scoops of vanilla ice cream, topped with brown sugar syrup and boba.",
               "price": 6,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000005400470567_1767168964.png"
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Hand-Shaved Ice 🍧",
+          "guid": "28769591-81ff-4560-898e-4c7bc5d9a646",
+          "description": "",
+          "items": [
+            {
+              "name": "H1 Strawberry Shaved Ice 🍧",
+              "guid": "d51a98da-68d7-4b30-8f74-516e5e3d874e",
+              "description": "Fresh strawberries, all-natural strawberry puree, condensed milk",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/2136a41d-7063-4dd2-9629-b40403f66456.png"
+            },
+            {
+              "name": "H2 Build You Own Shaved Ice 🍧",
+              "guid": "918649b1-5ca3-4588-8c58-f61aa793654e",
+              "description": "",
+              "price": 8,
+              "imageUrl": null
             }
           ]
         },
@@ -4740,95 +4817,151 @@
           "description": "",
           "items": [
             {
-              "name": "Tiger Milk with Boba 🐯🌙",
+              "name": "41 Tiger Milk with Boba 🐯🌙",
               "guid": "397c74f4-dd53-42ab-8d93-547792bb6f31",
               "description": "Fresh milk with handcrafted top grade brown sugar stripes — rich, creamy, and naturally caffeine-free 🌙 Served with boba. Our tapioca boba is made from scratch in Hayward with simple ingredients — no preservatives.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000004994025826_1766999024.png"
             },
             {
-              "name": "Vietnamese Iced Coffee 🇻🇳❄️☕️",
+              "name": "81 Vietnamese Iced Coffee 🇻🇳❄️☕️",
               "guid": "4a43aa3b-d998-4133-b4e4-1f5f09e28cd5",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000006208598079_1766829504.png"
             },
             {
-              "name": "Crème Brûlée Vietnamese Iced Coffee",
+              "name": "82 Crème Brûlée Vietnamese Iced Coffee",
               "guid": "77529224-ee41-4ca5-af0d-fd7abe5d4e8c",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans ☕❄ +  Crème Brûlée 🍮",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000005291458123_1766840134.png"
             },
             {
-              "name": "Mango Jasmine Green Tea with Mango Star Jelly 🥭⭐️",
+              "name": "Mango Jasmine Tea w/ Mango Star Jelly 🥭⭐️",
               "guid": "9b1893d1-b802-4f64-9ffe-d9fc0ed20015",
               "description": "Fragrant jasmine green tea brightened with juicy mango and fun star-shaped jelly.",
               "price": 7.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004993398070_1757106176.jpg"
             },
             {
-              "name": "Dino Freeze 🍓🥭🍑🦖❄️🌙",
+              "name": "75 Dino Freeze 🍓🥭🍑🦖❄️🌙",
               "guid": "f65e8ad8-357e-4cac-be70-685d9dc414c8",
               "description": "A frosty slush of your choices of real fruit purees blended into the ultimate sweet chill.",
               "price": 6.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/ee481775-1408-4e3a-9574-5b1dfc8958fa.png"
             },
             {
-              "name": "Lychee Jasmine Green",
+              "name": "51 Lychee Jasmine Green",
               "guid": "2a564dd9-bfdf-4478-af12-e9a2f6f961cd",
               "description": "jasmine green tea + lychee puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Mango Passionfruit Jasmine Green",
+              "name": "53 Mango Passionfruit Jasmine Green",
               "guid": "39403e9a-36da-4187-9d3b-3ceb1fe5cf53",
               "description": "jasmine green tea + mango and passionfruit puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Ube Taro Milk with Boba 🍠🍯🌙",
-              "guid": "694b51e6-58d9-4fea-9505-b159610b2d91",
-              "description": "Made with real taro and ube, without artificial colors or flavors.",
-              "price": 8.25,
-              "imageUrl": null
-            },
-            {
-              "name": "Mango Grapefruit Crystal 🥭🥥💎(🌙)",
+              "name": "74 Mango Grapefruit Crystal 🥭🥥💎(🌙)",
               "guid": "47908528-b0f5-4977-ae65-e72fdfb14edc",
               "description": "organic mangos, jasmine tea, organic coconut milk, grapefruit pulp and crystal boba",
               "price": 8.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000005355541035_1770463715.png"
             },
             {
-              "name": "Strawberry Lemonade 🍓🍋🌙",
+              "name": "62 Strawberry Lemonade 🍓🍋🌙",
               "guid": "a139d893-5fd8-41b1-8cfc-75a414b02ce9",
               "description": "Made to order with fresh lemons, cane sugar, strawberry puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/f885eb1f-5056-4f95-aac5-388e287932b4.png"
             },
             {
-              "name": "Assam Black Milk Tea with Boba 🧋🍯",
-              "guid": "e53f98bd-b769-472f-8eee-a9d974f2f0bf",
-              "description": "Bold and malty Assam black tea swirled with creamy milk and chewy boba.",
-              "price": 7.5,
-              "imageUrl": null
-            },
-            {
-              "name": "Strawberry Matcha Latte 🍓🍵",
+              "name": "33 Strawberry Matcha Latte 🍓🍵",
               "guid": "9f638a67-3997-4db2-892a-1a94f2f0d8fb",
               "description": "Top grade Japanese Royal matcha, organic strawberries",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/e7b9194f-b34e-4fe4-9661-22e8a6f3443e.png"
             },
             {
-              "name": "Crème Brûlée Tiger Milk (with Boba) 🌙",
+              "name": "42 Crème Brûlée Tiger Milk (with Boba) 🌙",
               "guid": "0c7bad54-8207-4bbd-9501-f8e71823a4ec",
               "description": "",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000008087959751_1768258758.png"
+            }
+          ]
+        },
+        {
+          "name": "🆕 Tea-Rek’z Signatures 🦖",
+          "guid": "8560d500-596f-424d-8b50-3b7fd4264f30",
+          "description": "Featuring rare drinks like our cold brewed magnolia green tea creations, fresh cream toppings made without artificial creamers, and all-natural fruit ingredients for a cleaner, more premium drink experience.",
+          "items": [
+            {
+              "name": "S1 Magnolia Cloud",
+              "guid": "ef9f74db-5f45-412a-9451-5ffee16b85c3",
+              "description": "Magnolia Green Tea with Jasmine Cream. Best enjoyed without boba.",
+              "price": 7.5,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/19c63b47-b769-4dc8-b248-f3c071e3a731.png"
+            },
+            {
+              "name": "S2 Magnolia Velvet",
+              "guid": "c3832cb2-69af-45c7-8cb3-1bf38ba123c3",
+              "description": "Magnolia Green Tea with Sea Salt Cheese Cream. Best enjoyed without boba.",
+              "price": 7.5,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000011091561172_1778489973.png"
+            },
+            {
+              "name": "S3 Magnolia Matcha Cloud",
+              "guid": "d7e18553-ed9e-4048-bfb2-7c61465b9c93",
+              "description": "Magnolia Green Tea with Matcha Cream. Best enjoyed without boba.",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000011091561174_1778490002.png"
+            },
+            {
+              "name": "S4 Magnolia Orchard",
+              "guid": "be2f0cab-d4fe-4f70-bba6-951c8435f2fa",
+              "description": "Lychee and Peach Magnolia Green Tea with Jasmine Cream. Best enjoyed without boba.",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/6a335c51-2baf-4041-95b6-ce57dcf4cc73.png"
+            },
+            {
+              "name": "S5 Lychee Blossom",
+              "guid": "0da520c1-3aa2-4b8a-8ae6-1897e83b09ad",
+              "description": "Lychee Jasmine Green Tea with Jasmine Cream",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000011091561178_1778490072.png"
+            },
+            {
+              "name": "S6 Pistachio Cream Coffee",
+              "guid": "f5ad4454-05d8-45f8-848a-a9ad018d5045",
+              "description": "Vietnamese Iced Coffee with Pistachio Cream",
+              "price": 8,
+              "imageUrl": null
+            },
+            {
+              "name": "S7 Matcha Blossom",
+              "guid": "d454ff49-5c40-4dab-a3d8-4d7118b8e057",
+              "description": "Matcha Latte with Raspberry Cream",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000011091561182_1778490107.jpg"
+            },
+            {
+              "name": "S8 Strawberry Pop Milk",
+              "guid": "9afbd0f0-4641-4db4-a981-5e2bab4aa0fa",
+              "description": "Organic strawberries, fresh milk, and naturally colored strawberry popping boba",
+              "price": 7.5,
+              "imageUrl": null
+            },
+            {
+              "name": "S9 Mango Pop Milk",
+              "guid": "c11fa717-2877-4b32-a43d-fe7bce021e36",
+              "description": "Organic mango, fresh milk, and naturally colored mango popping boba",
+              "price": 7.5,
+              "imageUrl": null
             }
           ]
         },
@@ -4838,63 +4971,35 @@
           "description": "Freshly brewed with purified mineral water.",
           "items": [
             {
-              "name": "Jasmine Green Tea",
+              "name": "1 Jasmine Green Tea",
               "guid": "6636abcc-be69-4fe1-9fd1-85b03e597b55",
               "description": "",
               "price": 5.75,
               "imageUrl": null
             },
             {
-              "name": "Lychee Black Tea",
+              "name": "2 Magnolia Green Tea",
+              "guid": "1c375b46-e404-4632-9428-f5914ae23cf4",
+              "description": "Cold brewed green tea scented with magnolia flowers for a smooth, floral, naturally sweet, zero-bitterness finish.",
+              "price": 6,
+              "imageUrl": null
+            },
+            {
+              "name": "3 Lychee Black Tea",
               "guid": "cc2821e8-c4f0-4d80-8bc7-0f59fbfa37d9",
               "description": "A fragrant black tea with natural lychee aroma, smooth and floral with a subtle fruity finish. Refreshing on its own, without added sweetness.",
               "price": 5.75,
               "imageUrl": null
             },
             {
-              "name": "Earl Grey Tea",
-              "guid": "51b2111a-ac9c-4547-92af-c515197c8b1f",
-              "description": "Bold black tea infused with fragrant bergamot citrus for a smooth, aromatic finish.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "White Peach Oolong Tea",
+              "name": "4 White Peach Oolong Tea",
               "guid": "85a64a76-cc44-4db5-b85c-47314a48cdda",
               "description": "A smooth, floral oolong with a natural white peach aroma. Light and refreshing with a subtle fruit fragrance, not sweet on its own.",
-              "price": 5.75,
+              "price": 6,
               "imageUrl": null
             },
             {
-              "name": "White Grape Oolong Tea",
-              "guid": "d6349841-dc34-4eeb-b256-4c8c037739d9",
-              "description": "A fragrant oolong with the delicate aroma of white grapes. Crisp and refreshing, smooth and floral, not sweet on its own.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "Four Seasons Jade Oolong",
-              "guid": "e9224a1d-12a8-4591-b3a4-7bc2b98604de",
-              "description": "A lightly roasted Taiwanese oolong with a bright, floral aroma and smooth, refreshing finish. Balanced between green and oolong, it’s crisp yet delicate.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "High Mountain Oolong",
-              "guid": "00d8e850-86e2-4116-9736-d4c992d74204",
-              "description": "Cold brewed for a smooth, naturally creamy cup with a clean finish.\r\nLight sweetness recommended — extra sugar will overpower the tea.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "High Mountain Jasmine",
-              "guid": "ca5d6b9e-1e5f-4b61-9f8a-046517f3bd84",
-              "description": "A blend of High Mountain Oolong and Jasmine Green Tea. Cold brewed for a smooth, naturally creamy cup with a clean finish.\r\nLight sweetness recommended — extra sugar will overpower the tea.",
-              "price": 5.75,
-              "imageUrl": null
-            },
-            {
-              "name": "Rooibos Tea 🌙",
+              "name": "5 Rooibos Tea 🌙",
               "guid": "47d3cd45-c531-4553-a20a-7054195b565b",
               "description": "Naturally caffeine-free 🌙 herbal tea from South Africa, with a smooth, earthy flavor and gentle notes of honey and vanilla.",
               "price": 5.75,
@@ -4908,74 +5013,67 @@
           "description": "",
           "items": [
             {
-              "name": "Jasmine Green Milk Tea",
-              "guid": "0f1c0cab-e4aa-4019-86d5-17941569a927",
-              "description": "Fragrant, floral, and refreshing with a light creamy finish.",
-              "price": 6.75,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004992513670_1766830576.png"
-            },
-            {
-              "name": "Jasmine Milk Tea with Matcha Cream",
-              "guid": "18895557-c944-4f3f-87d5-da0bd143b504",
-              "description": "Jasmine milk tea topped with matcha cream",
-              "price": 8.25,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000008087703153_1768259982.png"
-            },
-            {
-              "name": "Lychee Black Milk Tea",
+              "name": "21 Lychee Black Milk Tea",
               "guid": "6fd9f266-9d5e-44aa-8284-665b1b5e52fd",
               "description": "Smooth black tea with a natural lychee fragrance, blended with creamy milk for a floral, subtly fruity cup. Light and aromatic, not sweet on its own.",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Assam Black Milk Tea",
+              "name": "22 Assam Black Milk Tea",
               "guid": "e41b7556-b795-4f70-b6c8-4ffbd9773bba",
               "description": "Bold, malty, and robust — the classic milk tea taste.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004994025820_1766831402.png"
             },
             {
-              "name": "Ceylon Milk Tea",
-              "guid": "df24d483-c541-4a25-8340-38a071c83e89",
-              "description": "Bold, malty, and robust — the classic milk tea taste.",
-              "price": 6.75,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004994025820_1766831402.png"
-            },
-            {
-              "name": "Roasted Oolong Milk Tea",
+              "name": "23 Roasted Oolong Milk Tea",
               "guid": "e6851d44-4c4d-4cbd-a394-bdb066872406",
               "description": "Toasty, nutty, and smooth with balanced depth.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000004994025822_1757106082.jpg"
             },
             {
-              "name": "Classic Thai Tea 🇹🇭🫖",
+              "name": "24 Classic Thai Tea 🇹🇭🫖",
               "guid": "5b5e969a-bf1d-44f2-a67c-69fd5f704731",
               "description": "Bold, spiced Thai black tea layered with organic half & half — smooth, rich, and served at fixed sweetness.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004994025830_1766817442.png"
             },
             {
-              "name": "Crème Brûlée Classic Thai Tea",
+              "name": "25 Crème Brûlée Classic Thai Tea",
               "guid": "6a9c1c33-4329-4399-9279-7eddcb70cfcb",
               "description": "Classic Thai Tea + Crème Brûlée",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000005291465641_1772013526.jpg"
             },
             {
-              "name": "White Peach Oolong Milk Tea",
-              "guid": "247193a1-42f6-4dc0-a41a-7cb4776981f6",
-              "description": "",
-              "price": 6.75,
-              "imageUrl": null
-            },
-            {
-              "name": "Assam Masala Chai Tea 🇮🇳☕",
+              "name": "26 Assam Masala Chai Tea 🇮🇳☕",
               "guid": "dabb98d5-def4-49d1-9b7b-b8e392114945",
               "description": "Bold Assam black tea with aromatic Indian spices — smooth, spicy, and deeply comforting.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/4627b8d1-96ae-4f78-aefe-50e9491d6f55.jpg"
+            },
+            {
+              "name": "27 Jasmine Green Milk Tea",
+              "guid": "0f1c0cab-e4aa-4019-86d5-17941569a927",
+              "description": "Fragrant, floral, and refreshing with a light creamy finish.",
+              "price": 6.75,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000004992513670_1766830576.png"
+            },
+            {
+              "name": "28 White Peach Oolong Milk Tea",
+              "guid": "ac06f7df-2155-4d3a-af8d-6e0f8faaa0f9",
+              "description": "Fragrant oolong tea with a delicate white peach aroma, blended with creamy milk for a smooth, floral, and subtly fruity taste. Naturally not sweet on its own.",
+              "price": 7,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000005129626884_1757235096.jpg"
+            },
+            {
+              "name": "29 Rooibos Milk Tea🌙",
+              "guid": "b694a634-dfb5-40fb-a28a-accf27351324",
+              "description": "Naturally caffeine-free rooibos blended with creamy milk for a smooth, earthy cup with gentle notes of honey and vanilla.",
+              "price": 6.75,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000005129626888_1757235175.jpg"
             }
           ]
         },
@@ -4985,49 +5083,42 @@
           "description": "Made with royal Japanese matcha and fresh milk.",
           "items": [
             {
-              "name": "Matcha Latte 🍵",
+              "name": "31 Matcha Latte 🍵",
               "guid": "38020157-0819-4e45-bda3-b1f8e98e6bd7",
               "description": "Top grade Japanese Royal matcha",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/e1fd77d1-e1a7-4ad7-98f2-36e884cc4e69.png"
             },
             {
-              "name": "Brown Sugar Matcha Latte 🍵",
+              "name": "32 Brown Sugar Matcha Latte 🍵",
               "guid": "5cf93bf6-076d-418d-b601-a55609743f40",
               "description": "Top grade Japanese Royal matcha and handcrafted top grade brown sugar.",
               "price": 7.25,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/0/item-1300000005129736630_1766830179.png"
             },
             {
-              "name": "Strawberry Matcha Latte 🍓🍵",
+              "name": "33 Strawberry Matcha Latte 🍓🍵",
               "guid": "9f638a67-3997-4db2-892a-1a94f2f0d8fb",
               "description": "Top grade Japanese Royal matcha, organic strawberries",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/e7b9194f-b34e-4fe4-9661-22e8a6f3443e.png"
             },
             {
-              "name": "Mango Matcha Latte 🥭🍵",
+              "name": "34 Mango Matcha Latte 🥭🍵",
               "guid": "1124c118-18f6-4148-aefe-bdaccf56313f",
               "description": "Top grade Japanese Royal matcha, organic mangos",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/a9066480-ceea-44c8-b5d2-44b07892385e.png"
             },
             {
-              "name": "Taro Matcha Latte 🍠🍵",
+              "name": "35 Taro Matcha Latte 🍠🍵",
               "guid": "c4924a80-f3da-4e0e-bd6c-406f21853eae",
               "description": "Top grade Japanese Royal matcha, real taro and ube.",
               "price": 8.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000008109510341_1772013412.jpg"
             },
             {
-              "name": "Double Matcha 🍵🍵",
-              "guid": "07287a93-4d37-4d87-9e67-5d4762badc83",
-              "description": "Matcha Milk Tea with Matcha Cream",
-              "price": 8.5,
-              "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000008087662787_1768259398.jpg"
-            },
-            {
-              "name": "Dalgona Matcha Latte 🍯🍵",
+              "name": "36 Dalgona Matcha Latte 🍯🍵",
               "guid": "4a78efb8-8262-4ec5-a583-083c33d7793a",
               "description": "Creamy matcha with honeycomb toffee-like dalgona crumbles for a sweet, toasty crunch, inspired by the Korean street treat in Squid Game.",
               "price": 7.5,
@@ -5041,56 +5132,42 @@
           "description": "",
           "items": [
             {
-              "name": "Tiger Milk with Boba 🐯🌙",
+              "name": "41 Tiger Milk with Boba 🐯🌙",
               "guid": "397c74f4-dd53-42ab-8d93-547792bb6f31",
               "description": "Fresh milk with handcrafted top grade brown sugar stripes — rich, creamy, and naturally caffeine-free 🌙 Served with boba. Our tapioca boba is made from scratch in Hayward with simple ingredients — no preservatives.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000004994025826_1766999024.png"
             },
             {
-              "name": "Crème Brûlée Tiger Milk (with Boba) 🌙",
+              "name": "42 Crème Brûlée Tiger Milk (with Boba) 🌙",
               "guid": "0c7bad54-8207-4bbd-9501-f8e71823a4ec",
               "description": "",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000008087959751_1768258758.png"
             },
             {
-              "name": "Assam Tiger Milk with Boba 🐯",
-              "guid": "147bff69-088e-4b37-9ca6-8b7a7ca06701",
-              "description": "Our signature Tiger Milk infused with a subtle layer of Assam black tea. Milk-forward, caramel-rich, with just a whisper of malty depth.",
-              "price": 8,
-              "imageUrl": null
-            },
-            {
-              "name": "Jasmine Tiger Milk with Boba 🐯",
-              "guid": "d8f82863-c65b-48c0-9ad8-9329ab8ae84d",
-              "description": "Our signature Tiger Milk layered with a subtle jasmine tea essence. Silky, fragrant, and softly floral.",
-              "price": 8,
-              "imageUrl": null
-            },
-            {
-              "name": "Ube Taro Milk 🍠🌙",
+              "name": "43 Ube Taro Milk 🍠🌙",
               "guid": "29ed0bdd-c183-4b76-8a6e-0b9861d806e9",
               "description": "Real taro and real Ube blended with milk — naturally creamy, with no artificial colors or flavors.",
               "price": 7.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/2/item-1300000004994025832_1766816106.png"
             },
             {
-              "name": "Strawberry Milk 🍓🥛🌙",
+              "name": "44 Strawberry Milk 🍓🥛🌙",
               "guid": "6d16adff-8a04-4f07-a599-ae2645ce50a5",
               "description": "organic strawberries and fresh milk",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000008620469457_1770420574.png"
             },
             {
-              "name": "Korean Mango Milk 🥭🥛🌙",
+              "name": "45 Korean Mango Milk 🥭🥛🌙",
               "guid": "50f1ea8a-b89b-4c45-be62-b15826e553b2",
               "description": "organic mango and fresh milk",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000009018273524_1772013435.jpg"
             },
             {
-              "name": "Horchata de Avena 🍂🥛🌙",
+              "name": "46 Horchata de Avena 🍂🥛🌙",
               "guid": "b32f9dfb-6c88-44f4-b91a-69d12e08ff0e",
               "description": "oat milk horchata",
               "price": 7,
@@ -5104,28 +5181,35 @@
           "description": "",
           "items": [
             {
-              "name": "Lychee Jasmine Green",
+              "name": "51 Lychee Jasmine Green",
               "guid": "2a564dd9-bfdf-4478-af12-e9a2f6f961cd",
               "description": "jasmine green tea + lychee puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Strawberry Peach Jade Oolong",
+              "name": "52 Strawberry Peach Jade Oolong",
               "guid": "fea5b79b-9c7e-42e6-b860-960a218b071e",
               "description": "freshly brewed four seasons jade oolong + strawberry and peach puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Mango Passionfruit Jasmine Green",
+              "name": "53 Mango Passionfruit Jasmine Green",
               "guid": "39403e9a-36da-4187-9d3b-3ceb1fe5cf53",
               "description": "jasmine green tea + mango and passionfruit puree",
               "price": 6.75,
               "imageUrl": null
             },
             {
-              "name": "Build Your Own Fruit Tea  🍓🌱",
+              "name": "54 Peach Lychee Magnolia Green",
+              "guid": "999648d8-5a23-46d5-826e-78626e6891a9",
+              "description": "",
+              "price": 7,
+              "imageUrl": null
+            },
+            {
+              "name": "55 Build Your Own Fruit Tea  🍓🌱",
               "guid": "81bebd73-204d-4c9e-b333-07c85946cae1",
               "description": "",
               "price": 6.75,
@@ -5139,49 +5223,49 @@
           "description": "",
           "items": [
             {
-              "name": "Lemonade 🍋🌙",
+              "name": "61 Lemonade 🍋🌙",
               "guid": "19c3f8bd-1fc8-41f9-a148-5ed5334b3513",
               "description": "Made to order with fresh lemons, cane sugar, and purified mineral water — never pre-made.",
               "price": 6,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000005291429206_1766827502.png"
             },
             {
-              "name": "Strawberry Lemonade 🍓🍋🌙",
+              "name": "62 Strawberry Lemonade 🍓🍋🌙",
               "guid": "a139d893-5fd8-41b1-8cfc-75a414b02ce9",
               "description": "Made to order with fresh lemons, cane sugar, strawberry puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/f885eb1f-5056-4f95-aac5-388e287932b4.png"
             },
             {
-              "name": "Mango Lemonade 🥭🍋🌙",
+              "name": "63 Mango Lemonade 🥭🍋🌙",
               "guid": "21e5141b-a3ec-4df9-a367-7d0aa7b9ea2a",
               "description": "Made to order with fresh lemons, cane sugar, mango puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000005355804257_1758274181.jpg"
             },
             {
-              "name": "Passionfruit Lemonade 🍋🌙",
+              "name": "64 Passionfruit Lemonade 🍋🌙",
               "guid": "eb3d2a9c-ae85-4319-b895-688a8b8f3f1b",
               "description": "Made to order with fresh lemons, cane sugar, passionfruit puree and purified mineral water — never pre-made.",
               "price": 7,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/8/item-1300000005355808498_1758274196.jpg"
             },
             {
-              "name": "Purple Lemonade 🔮🍋🌙",
+              "name": "65 Purple Lemonade 🔮🍋🌙",
               "guid": "38106a34-9d29-4d18-a28c-2e4cda6143bd",
               "description": "A color-changing twist of fresh lemonade + passionfruit, and butterfly pea tea — bright, tangy, and magically purple! 🦖🍋💜✨",
               "price": 7.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000006111297916_1766828237.png"
             },
             {
-              "name": "Rose Hibiscus Lemonade 🌹🌺🍋🌙",
+              "name": "66 Rose Hibiscus Lemonade 🌹🌺🍋🌙",
               "guid": "04963db2-a9f9-4908-8fcd-5f28fdd2b0b8",
               "description": "",
               "price": 7,
               "imageUrl": null
             },
             {
-              "name": "Ginger Lemonade 🫚🍋🌙",
+              "name": "67 Ginger Lemonade 🫚🍋🌙",
               "guid": "a23a33e3-a783-4542-9622-4380aeb4b987",
               "description": "Made to order with fresh lemons, cane sugar, ginger puree and purified mineral water — never pre-made.",
               "price": 7,
@@ -5195,35 +5279,35 @@
           "description": "",
           "items": [
             {
-              "name": "Golden Mango 🥭🌙",
+              "name": "71 Golden Mango 🥭🌙",
               "guid": "5e3df891-b445-4aff-b828-a18665436d43",
               "description": "Over half a pound organic mangos + golden cane sugar + purified mineral water.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/1/item-1300000007709137801_1770463661.png"
             },
             {
-              "name": "Jasmine Mango 🫖🥭",
+              "name": "72 Jasmine / Magnolia Mango 🫖🥭",
               "guid": "6c07b946-0cf5-4384-8c46-5ad9a70f5fdc",
               "description": "Over half a pound organic mangos + golden cane sugar + jasmine tea.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000007709137803_1770463677.png"
             },
             {
-              "name": "Coco Mango 🥥🥭🌙",
+              "name": "73 Coco Mango 🥥🥭🌙",
               "guid": "b0212c8a-b50f-40a0-8ca7-f0d23d06d144",
               "description": "Over half a pound organic mangos + golden cane sugar + pistachios.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000007709137805_1770463698.png"
             },
             {
-              "name": "Mango Grapefruit Crystal 🥭🥥💎(🌙)",
+              "name": "74 Mango Grapefruit Crystal 🥭🥥💎(🌙)",
               "guid": "47908528-b0f5-4977-ae65-e72fdfb14edc",
               "description": "organic mangos, jasmine tea, organic coconut milk, grapefruit pulp and crystal boba",
               "price": 8.5,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/5/item-1300000005355541035_1770463715.png"
             },
             {
-              "name": "Dino Freeze 🍓🥭🍑🦖❄️🌙",
+              "name": "75 Dino Freeze 🍓🥭🍑🦖❄️🌙",
               "guid": "f65e8ad8-357e-4cac-be70-685d9dc414c8",
               "description": "A frosty slush of your choices of real fruit purees blended into the ultimate sweet chill.",
               "price": 6.5,
@@ -5237,42 +5321,42 @@
           "description": "",
           "items": [
             {
-              "name": "Vietnamese Iced Coffee 🇻🇳❄️☕️",
+              "name": "81 Vietnamese Iced Coffee 🇻🇳❄️☕️",
               "guid": "4a43aa3b-d998-4133-b4e4-1f5f09e28cd5",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans.",
               "price": 6.75,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/9/item-1300000006208598079_1766829504.png"
             },
             {
-              "name": "Crème Brûlée Vietnamese Iced Coffee",
+              "name": "82 Crème Brûlée Vietnamese Iced Coffee",
               "guid": "77529224-ee41-4ca5-af0d-fd7abe5d4e8c",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans ☕❄ +  Crème Brûlée 🍮",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/3/item-1300000005291458123_1766840134.png"
             },
             {
-              "name": "Vietnamese Iced Coffee with Pistachio Cream",
+              "name": "83 Pistachio Cream Vietnamese Iced Coffee",
               "guid": "df813baf-d827-4490-8bb6-5f1f1b450f2f",
               "description": "Crafted with freshly ground authentic Vietnamese Robusta beans ☕❄ +  Pistachio Cream.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000007709066774_1772013562.jpg"
             },
             {
-              "name": "Dino Fuel (Vietnamese Coffee x Thai Tea) 🇻🇳🇹🇭⚡️",
+              "name": "84 Dino Fuel (Vietnamese Coffee x Thai Tea) 🇻🇳🇹🇭⚡️",
               "guid": "a842bbf8-69e7-4683-a3de-69e8186c5b51",
               "description": "Also called \"Dirty Thai Tea\", smooth Thai milk tea blended with double shots of espresso for a perfect mix of sweetness, spice, and caffeine kick. Ice and sweetness level are fixed.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/4/item-1300000006111243964_1766829653.png"
             },
             {
-              "name": "Dirty Horchata de Avena 🍂🥛☕️",
+              "name": "85 Dirty Horchata de Avena 🍂🥛☕️",
               "guid": "4e68814f-c46c-413f-914e-f259e35f0a40",
               "description": "Oat milk Horchata + Vietnamese coffee.",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/6/item-1300000008620842186_1770420855.png"
             },
             {
-              "name": "Vietnamese Mocha 🇻🇳🍫☕️",
+              "name": "86 Vietnamese Mocha 🇻🇳🍫☕️",
               "guid": "ca78141b-77ba-4f33-b5f9-b1b62b31abe9",
               "description": "Crafted with organic cocoa, fresh milk, and traditional butter-roasted Vietnamese coffee for a mocha that’s intense, velvety, and unforgettable.",
               "price": 8,
@@ -5286,35 +5370,35 @@
           "description": "",
           "items": [
             {
-              "name": "Hazelnut Hot Chocolate 🍫☕🌙",
+              "name": "91 Hazelnut Hot Chocolate 🍫☕🌙",
               "guid": "ed047973-c0cd-4bb7-8309-a6344a3260d4",
               "description": "Crafted with organic cocoa, fresh milk, and roasted hazelnut for a luxuriously smooth, deeply chocolatey experience.",
               "price": 6,
               "imageUrl": null
             },
             {
-              "name": "Jasmine Hot Chocolate 🍫☕🌙",
+              "name": "92 Jasmine Hot Chocolate 🍫☕🌙",
               "guid": "03c70935-3d44-46fc-91c5-e30104278a23",
               "description": "Deep organic cocoa meets a whisper of jasmine tea for a refined twist on classic hot chocolate — rich, smooth, and lightly floral.",
               "price": 7,
               "imageUrl": null
             },
             {
-              "name": "Masala Chai Hot Chocolate 🍫☕🌙",
+              "name": "93 Masala Chai Hot Chocolate 🍫☕🌙",
               "guid": "5e81bce7-e5b9-4773-9ec2-3b2dbd771a79",
               "description": "Organic cocoa blended with steamed milk, warm chai spices, and a subtle touch of Assam tea. Rich, aromatic, and gently spiced.",
               "price": 8,
               "imageUrl": null
             },
             {
-              "name": "Hot Honey Yuzu Tea 🍋🍯🌙",
+              "name": "94 Hot Honey Yuzu Tea 🍋🍯🌙",
               "guid": "1bf35892-edda-481c-b34c-e4628cc49ab4",
               "description": "A comforting blend of honey and yuzu citrus, served hot for a soothing, lightly sweet and tangy cup.",
               "price": 5,
               "imageUrl": null
             },
             {
-              "name": "Hot Ginger Honey Yuzu Tea 🍋🍯🫚🌙",
+              "name": "95 Hot Ginger Honey Yuzu Tea 🍋🍯🫚🌙",
               "guid": "c333b873-5dfe-40f7-9384-50cb1e38ed99",
               "description": "Fragrant yuzu citrus blended with honey and fresh ginger for a warm, soothing cup with bright citrus and gentle spice.",
               "price": 6,
@@ -5328,18 +5412,39 @@
           "description": "",
           "items": [
             {
-              "name": "Fresh Squeezed Orange Juice 🍊🌙",
+              "name": "98 Fresh Squeezed Orange Juice 🍊🌙",
               "guid": "d8f92398-3afc-40cb-94c0-201ef8540dcb",
               "description": "Our most loved fresh squeezed orange juice from Skillet'z in a boba cup!",
               "price": 8,
               "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/db883614-824a-46fa-b18c-b285af488d7f.png"
             },
             {
-              "name": "Boba Sundae 🧋🍨🌙",
+              "name": "99 Boba Sundae 🧋🍨🌙",
               "guid": "66f34a9c-b1e2-469b-be05-94e120b77c9f",
               "description": "Two large scoops of vanilla ice cream, topped with brown sugar syrup and boba.",
               "price": 6,
               "imageUrl": "https://toasttab.s3.amazonaws.com/restaurants/restaurant-244719000000000000/menu/items/7/item-1300000005400470567_1767168964.png"
+            }
+          ]
+        },
+        {
+          "name": "Hawaiian Hand-Shaved Ice 🍧",
+          "guid": "0b41f464-02a9-4682-9ff9-ca0762cd352f",
+          "description": "",
+          "items": [
+            {
+              "name": "H1 Strawberry Shaved Ice 🍧",
+              "guid": "d51a98da-68d7-4b30-8f74-516e5e3d874e",
+              "description": "Fresh strawberries, all-natural strawberry puree, condensed milk",
+              "price": 8,
+              "imageUrl": "https://toasttab.s3.amazonaws.com/menu_service/restaurants/2d838293-2776-4151-b65b-1c9eea686461/MenuItem/2136a41d-7063-4dd2-9629-b40403f66456.png"
+            },
+            {
+              "name": "H2 Build You Own Shaved Ice 🍧",
+              "guid": "918649b1-5ca3-4588-8c58-f61aa793654e",
+              "description": "",
+              "price": 8,
+              "imageUrl": null
             }
           ]
         },

--- a/src/data/menu/processed/menu_option_groups.json
+++ b/src/data/menu/processed/menu_option_groups.json
@@ -2044,84 +2044,84 @@
           "name": "Boba (tapioca) ⚫️",
           "guid": "9c4c60b3-b0be-4326-93a2-31eedd3e37db",
           "description": "Classic honey-sweetened tapioca pearls",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Mango Popping Boba 🟠",
           "guid": "523809b3-a4f8-4cfc-8061-175bd38c601c",
           "description": "Bursting mango-flavored boba",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Strawberry Popping Boba 🔴",
           "guid": "1684ef1f-2f3f-409d-bba6-ead4d692ce59",
           "description": "Bursting strawberry-flavored boba",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Lychee Popping Boba ⚪️",
           "guid": "9d1063c9-acde-4988-bea1-1612e28607fe",
           "description": "Bursting lychee-flavored boba",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Mango Star Jelly ⭐️",
           "guid": "0f46f70c-ff24-4650-97aa-72cac7215a2e",
           "description": "Star-shaped mango jelly",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Strawberry Heart Jelly ❤️",
           "guid": "125f5ecb-0668-412d-8458-b62652de53b1",
           "description": "Heart-shaped strawberry jelly",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Lychee Jelly 🤍",
           "guid": "dacfef9b-5a8b-4c94-b0e2-398d2f9c2f31",
           "description": "Delicate lychee jelly",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Agar Crystal Boba 💎",
           "guid": "aa42fe8c-a3f7-4dbe-8950-5d7799e2b227",
           "description": "",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Agar Brown Sugar Boba 🍯",
           "guid": "53b21d05-a78f-4af0-9bc7-c4f5f2ed10b4",
           "description": "",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Dalgona (Honeycomb Toffee)",
           "guid": "0b7602e4-6cf6-450e-ad19-db6b4b0cd56f",
           "description": "",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Grapefruit Pulp",
           "guid": "57294a4b-463d-47f5-87b6-4159568d9ee4",
           "description": "",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         },
         {
           "name": "Diced Mango",
           "guid": "072343dd-6e83-46f9-bbf5-ad502226921a",
           "description": "",
-          "price": 0,
+          "price": 0.75,
           "orderableOnline": "YES"
         }
       ]
@@ -2459,77 +2459,19 @@
           "description": "",
           "price": 0,
           "orderableOnline": "YES"
-        }
-      ]
-    },
-    {
-      "name": "Sweetness Level (10% minimum)",
-      "guid": "96b9e7c6-dd56-4aa4-be66-0195f31d58ca",
-      "minSelections": 1,
-      "maxSelections": 1,
-      "pricingMode": "ADJUSTS_PRICE",
-      "items": [
+        },
         {
-          "name": "100% sweet (cane sugar)",
-          "guid": "6533c0bd-89f0-4f76-8ca7-9d628b021e36",
+          "name": "Raspberry",
+          "guid": "46ce2b0b-f0e3-400e-96f7-34674de24aaf",
           "description": "",
           "price": 0,
           "orderableOnline": "YES"
         },
         {
-          "name": "75% sweet (cane sugar)",
-          "guid": "670184fa-613b-4c94-8c39-e1c6bcb164ef",
+          "name": "Pineapple",
+          "guid": "c2203e23-7af4-4341-8a79-90bf3cdbc7a5",
           "description": "",
           "price": 0,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "50% sweet (cane sugar)",
-          "guid": "44bb65ae-8510-47e8-bd7c-88b39c57353a",
-          "description": "",
-          "price": 0,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "25% sweet (cane sugar)",
-          "guid": "7eea4f77-f3b2-4fe8-a247-e6b62b648319",
-          "description": "",
-          "price": 0,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "10% sweet (built in cane sugar)",
-          "guid": "1f57c949-6a81-4715-a609-6fef9081caed",
-          "description": "",
-          "price": 0,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "100% sweet (monk fruit added)",
-          "guid": "6fdd0235-1908-4118-96a4-a022e09e36c2",
-          "description": "",
-          "price": 0.5,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "75% sweet (monk fruit added)",
-          "guid": "69aac531-a317-4204-a92a-eac1dea7b8a3",
-          "description": "",
-          "price": 0.5,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "50% sweet (monk fruit added)",
-          "guid": "f87200d6-a036-4cd0-916c-7afaed93ae70",
-          "description": "",
-          "price": 0.5,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "25% sweet (monk fruit added)",
-          "guid": "f87200d6-a036-4cd0-916c-7afaed93ae70",
-          "description": "",
-          "price": 0.5,
           "orderableOnline": "YES"
         }
       ]
@@ -2755,29 +2697,6 @@
       ]
     },
     {
-      "name": "Milk Option (Milk Tea)",
-      "guid": "f9ecab33-4021-4084-8590-8730f783928d",
-      "minSelections": 1,
-      "maxSelections": 1,
-      "pricingMode": "ADJUSTS_PRICE",
-      "items": [
-        {
-          "name": "Dairy",
-          "guid": "7e22e8d2-a77a-4cb8-8911-094f56ab6c5e",
-          "description": "",
-          "price": 0,
-          "orderableOnline": "YES"
-        },
-        {
-          "name": "Oat",
-          "guid": "a5dbce3f-1eb0-4036-b362-d3d31f4568c6",
-          "description": "",
-          "price": 0.75,
-          "orderableOnline": "YES"
-        }
-      ]
-    },
-    {
       "name": "Ice Level (Tea-Rek'z)",
       "guid": "5804ddfa-f01e-4d62-ac39-677d735b5fc3",
       "minSelections": 1,
@@ -2808,17 +2727,63 @@
       ]
     },
     {
+      "name": "Add Kataifi",
+      "guid": "fba96742-2f42-4519-9aa2-b1463ba141e3",
+      "minSelections": 0,
+      "maxSelections": 1,
+      "pricingMode": "INCLUDED",
+      "items": [
+        {
+          "name": "Add kataifi on pistachio cream",
+          "guid": "da6059db-5c6b-4531-9d5b-92e85fb0fad3",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        }
+      ]
+    },
+    {
+      "name": "Milk Option (Milk Tea)",
+      "guid": "f9ecab33-4021-4084-8590-8730f783928d",
+      "minSelections": 1,
+      "maxSelections": 1,
+      "pricingMode": "ADJUSTS_PRICE",
+      "items": [
+        {
+          "name": "Dairy",
+          "guid": "7e22e8d2-a77a-4cb8-8911-094f56ab6c5e",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Oat",
+          "guid": "a5dbce3f-1eb0-4036-b362-d3d31f4568c6",
+          "description": "",
+          "price": 0.75,
+          "orderableOnline": "YES"
+        }
+      ]
+    },
+    {
       "name": "Choose a tea",
       "guid": "c2164949-3ddc-4520-b7cb-79b3672bdc37",
       "minSelections": 1,
       "maxSelections": 1,
-      "pricingMode": "INCLUDED",
+      "pricingMode": "ADJUSTS_PRICE",
       "items": [
         {
           "name": "Jasmine Green",
           "guid": "9f38673b-1a9e-4215-bb6f-e8ccae0c64bc",
           "description": "",
           "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Magnolia Green",
+          "guid": "e0061c54-f6ba-4c9a-abd4-9ca0b5a75993",
+          "description": "",
+          "price": 0.25,
           "orderableOnline": "YES"
         },
         {
@@ -2882,15 +2847,182 @@
       ]
     },
     {
-      "name": "Add Kataifi",
-      "guid": "fba96742-2f42-4519-9aa2-b1463ba141e3",
-      "minSelections": 0,
+      "name": "Choose a tea",
+      "guid": "62b9e0c1-1601-4d45-be4a-3b47225e88b3",
+      "minSelections": 1,
       "maxSelections": 1,
       "pricingMode": "INCLUDED",
       "items": [
         {
-          "name": "Add kataifi on pistachio cream",
-          "guid": "da6059db-5c6b-4531-9d5b-92e85fb0fad3",
+          "name": "Jasmine Green",
+          "guid": "9f38673b-1a9e-4215-bb6f-e8ccae0c64bc",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Magnolia Green",
+          "guid": "e0061c54-f6ba-4c9a-abd4-9ca0b5a75993",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        }
+      ]
+    },
+    {
+      "name": "No Condensed Milk",
+      "guid": "30762107-c554-4585-831b-0c12fdb4de9b",
+      "minSelections": 0,
+      "maxSelections": 1,
+      "pricingMode": "ADJUSTS_PRICE",
+      "items": [
+        {
+          "name": "No Condensed Milk",
+          "guid": "aba63ee0-b626-4e8a-ae5d-dbc7e161c1ab",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        }
+      ]
+    },
+    {
+      "name": "Choose a base flavor",
+      "guid": "b518bcab-1704-423b-8a76-6d4bc28e8089",
+      "minSelections": 1,
+      "maxSelections": 1,
+      "pricingMode": "INCLUDED",
+      "items": [
+        {
+          "name": "Strawberry 🍓",
+          "guid": "9224056f-3461-4da6-ac74-3aceb321c3cf",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Mango 🥭",
+          "guid": "ba3b9935-6374-4d35-8dad-987a66971e4f",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Passionfruit 💛",
+          "guid": "ee1ecb9b-4f61-411b-9b4d-071f9ffdf28d",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Peach 🍑",
+          "guid": "85adfbdb-7a60-48f4-90c3-6f3ba0159542",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Lychee",
+          "guid": "c3089b74-0457-47f2-aa46-a3fd302c3901",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Raspberry",
+          "guid": "46ce2b0b-f0e3-400e-96f7-34674de24aaf",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Pineapple",
+          "guid": "c2203e23-7af4-4341-8a79-90bf3cdbc7a5",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        }
+      ]
+    },
+    {
+      "name": "Add Toppings (shaved ice)",
+      "guid": "0d09c8b3-6860-4cc1-bfb6-0b5fc7795dcb",
+      "minSelections": 0,
+      "maxSelections": 3,
+      "pricingMode": "INCLUDED",
+      "items": [
+        {
+          "name": "Fresh Strawberries",
+          "guid": "624a7631-f897-4924-836e-696d15a37129",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Diced Mango",
+          "guid": "072343dd-6e83-46f9-bbf5-ad502226921a",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Grapefruit Pulp",
+          "guid": "57294a4b-463d-47f5-87b6-4159568d9ee4",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Mango Popping Boba 🟠",
+          "guid": "523809b3-a4f8-4cfc-8061-175bd38c601c",
+          "description": "Bursting mango-flavored boba",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Strawberry Popping Boba 🔴",
+          "guid": "1684ef1f-2f3f-409d-bba6-ead4d692ce59",
+          "description": "Bursting strawberry-flavored boba",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Lychee Popping Boba ⚪️",
+          "guid": "9d1063c9-acde-4988-bea1-1612e28607fe",
+          "description": "Bursting lychee-flavored boba",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Mango Star Jelly ⭐️",
+          "guid": "0f46f70c-ff24-4650-97aa-72cac7215a2e",
+          "description": "Star-shaped mango jelly",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Strawberry Heart Jelly ❤️",
+          "guid": "125f5ecb-0668-412d-8458-b62652de53b1",
+          "description": "Heart-shaped strawberry jelly",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Lychee Jelly 🤍",
+          "guid": "dacfef9b-5a8b-4c94-b0e2-398d2f9c2f31",
+          "description": "Delicate lychee jelly",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Agar Crystal Boba 💎",
+          "guid": "aa42fe8c-a3f7-4dbe-8950-5d7799e2b227",
+          "description": "",
+          "price": 0,
+          "orderableOnline": "YES"
+        },
+        {
+          "name": "Agar Brown Sugar Boba 🍯",
+          "guid": "53b21d05-a78f-4af0-9bc7-c4f5f2ed10b4",
           "description": "",
           "price": 0,
           "orderableOnline": "YES"


### PR DESCRIPTION
## Summary
- Refresh processed website menu data from the latest available Toast menu export (`2026-05-11`)
- Updates shared menu data, modifier option groups, and regenerated image mapping metadata

## Validation
- `npm run menu:process`
- `npm run menu:images`
- `npm run lint` (passed with existing `<img>` warnings)
- `make build` (passed; existing page-data/static-export warnings only; build artifacts intentionally not committed)

## Deployment
- PR only. Do not merge/deploy until explicitly approved.
